### PR TITLE
Add Indent files

### DIFF
--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -1,0 +1,15 @@
+" Vim indent file
+" Language:	C#
+" Maintainer:	Johannes Zellner <johannes@zellner.org>
+" Last Change:	Fri, 15 Mar 2002 07:53:54 CET
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+   finish
+endif
+let b:did_indent = 1
+
+" C# is like indenting C
+setlocal cindent
+
+let b:undo_indent = "setl cin<"

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -20,21 +20,36 @@ function! s:IsAttributeLine(line)
   return a:line =~? '^\s*\[[A-Za-z]' && a:line =~? '\]$'
 endf
 
+function! s:FindPreviousNonCompilerDirectiveLine(start_lnum)
+  for delta in range(0, a:start_lnum)
+    let lnum = a:start_lnum - delta
+    let line = getline(lnum)
+    let is_directive = s:IsCompilerDirective(line)
+    if !is_directive
+      return lnum
+    endif
+  endfor
+  return 0
+endf
+
 function! GetCSIndent(lnum) abort
-
-  let this_line = getline(a:lnum)
-  let previous_line = getline(a:lnum - 1)
-
   " Hit the start of the file, use zero indent.
   if a:lnum == 0
     return 0
   endif
 
+  let this_line = getline(a:lnum)
+
   " Compiler directives use zero indent if so configured.
   let is_first_col_macro = s:IsCompilerDirective(this_line) && stridx(&l:cinkeys, '0#') >= 0
+  if is_first_col_macro
+    return cindent(a:lnum)
+  endif
 
-  if !is_first_col_macro && s:IsAttributeLine(previous_code_line)
-    let ind = indent(a:lnum - 1)
+  let lnum = s:FindPreviousNonCompilerDirectiveLine(a:lnum - 1)
+  let previous_code_line = getline(lnum)
+  if s:IsAttributeLine(previous_code_line)
+    let ind = indent(lnum)
     return ind
   else
     return cindent(a:lnum)

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -23,8 +23,11 @@ function! GetCSIndent(lnum) abort
     return 0
   endif
 
+  " Compiler directives use zero indent if so configured.
+  let is_first_col_macro = this_line =~? '^\s*#' && stridx(&l:cinkeys, '0#') >= 0
+
   " If previous_line is an attribute line:
-  if previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
+  if !is_first_col_macro && previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
     let ind = indent(a:lnum - 1)
     return ind
   else

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -1,6 +1,11 @@
 " Vim indent file
-" Language:	C#
-" Maintainer:   Aquila Deus
+" Language:            C#
+" Maintainer:          Nick Jensen <nickspoon@gmail.com>
+" Former Maintainer:   Aquila Deus
+" Last Change:         2018-11-21
+" Filenames:           *.cs
+" License:             Vim (see :h license)
+" Repository:          https://github.com/nickspoons/vim-cs
 "
 
 " Only load this indent file when no other was loaded.

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -1,15 +1,36 @@
 " Vim indent file
 " Language:	C#
-" Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri, 15 Mar 2002 07:53:54 CET
+" Maintainer:   Aquila Deus
+"
 
 " Only load this indent file when no other was loaded.
-if exists("b:did_indent")
+if exists('b:did_indent')
    finish
 endif
 let b:did_indent = 1
 
-" C# is like indenting C
-setlocal cindent
 
-let b:undo_indent = "setl cin<"
+setlocal indentexpr=GetCSIndent(v:lnum)
+
+
+function! GetCSIndent(lnum) abort
+
+  let this_line = getline(a:lnum)
+  let previous_line = getline(a:lnum - 1)
+
+  " Hit the start of the file, use zero indent.
+  if a:lnum == 0
+    return 0
+  endif
+
+  " If previous_line is an attribute line:
+  if previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
+    let ind = indent(a:lnum - 1)
+    return ind
+  else
+    return cindent(a:lnum)
+  endif
+
+endfunction
+
+" vim:et:sw=2:sts=2

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -12,6 +12,13 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetCSIndent(v:lnum)
 
+function! s:IsCompilerDirective(line)
+  return a:line =~? '^\s*#'
+endf
+
+function! s:IsAttributeLine(line)
+  return a:line =~? '^\s*\[[A-Za-z]' && a:line =~? '\]$'
+endf
 
 function! GetCSIndent(lnum) abort
 
@@ -24,10 +31,9 @@ function! GetCSIndent(lnum) abort
   endif
 
   " Compiler directives use zero indent if so configured.
-  let is_first_col_macro = this_line =~? '^\s*#' && stridx(&l:cinkeys, '0#') >= 0
+  let is_first_col_macro = s:IsCompilerDirective(this_line) && stridx(&l:cinkeys, '0#') >= 0
 
-  " If previous_line is an attribute line:
-  if !is_first_col_macro && previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
+  if !is_first_col_macro && s:IsAttributeLine(previous_code_line)
     let ind = indent(a:lnum - 1)
     return ind
   else

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -1,0 +1,77 @@
+Given cs (a declaration with an attribute):
+  namespace UnitTest.SomeTest
+  {
+  [RequireComponent(typeof(Collider))]
+  class Test {
+  [SerializeField]
+  public string m_PrettyName = "";
+  }
+  }
+
+Execute:
+  normal! gg=G
+
+Expect (correct indentation):
+  namespace UnitTest.SomeTest
+  {
+      [RequireComponent(typeof(Collider))]
+      class Test {
+          [SerializeField]
+          public string m_PrettyName = "";
+      }
+  }
+
+Given cs (a declaration with a directive):
+  namespace UnitTest.SomeTest
+  {
+  class Test {
+  #if UNITY_EDITOR
+  public
+  #endif
+  string m_PrettyName = "";
+  }
+  }
+
+Execute:
+  normal! gg=G
+
+Expect (correct indentation):
+  namespace UnitTest.SomeTest
+  {
+      class Test {
+  #if UNITY_EDITOR
+          public
+  #endif
+              string m_PrettyName = "";
+      }
+  }
+
+Given cs (a declaration with an attribute interleaved with directive):
+  namespace UnitTest.SomeTest
+  {
+  [RequireComponent(typeof(Collider))]
+  class Test {
+  [SerializeField]
+  #if UNITY_EDITOR
+  public
+  #endif
+  string m_PrettyName = "";
+  }
+  }
+
+Execute:
+  normal! gg=G
+
+Expect (correct indentation):
+  namespace UnitTest.SomeTest
+  {
+      [RequireComponent(typeof(Collider))]
+      class Test {
+          [SerializeField]
+  #if UNITY_EDITOR
+          public
+  #endif
+              string m_PrettyName = "";
+      }
+  }
+


### PR DESCRIPTION
This repo is for the C# runtime files and vim includes three kinds:

* vim81/compiler/cs.vim
* vim81/syntax/cs.vim
* vim81/ftplugin/cs.vim
* vim81/indent/cs.vim

Currently only includes syntax, so this PR adds indent. Before @nickspoons took over, Johannes Zellner was the maintainer for syntax, indent, and ftplugin. I hope that means you'll accept maintainership of indent.

Users who have OrangeT/vim-csharp or OmniSharp/omnisharp-vim already have a C# indent, but this one builds on top of what's there. They will need to ensure vim-cs's indent is loaded first. I clone this repo to a name that occurs earlier (`~/.vim/bundle/aaa-cs-official`) and that works with pathogen. Other plugin managers may have methods for specifying load order.

I've included three tests. The last test is the use case that prompted me to make these changes and it demonstrates how this PR improves on other C# indent.