### PR TITLE
Switch csStorage and csCharacter to Structure

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -146,8 +146,8 @@ syn cluster	csAll	contains=csCharacter,csClassType,csComment,csContextualStateme
 hi def link	csType	Type
 hi def link	csClassType	Type
 hi def link	csIsType	Type
-hi def link	csStorage	StorageClass
-hi def link	csClass	StorageClass
+hi def link	csStorage	Structure
+hi def link	csClass	Structure
 hi def link	csRepeat	Repeat
 hi def link	csConditional	Conditional
 hi def link	csLabel	Label


### PR DESCRIPTION
StorageClass is for things that modify the kind of storage (like
csModifier), whereas Structure is for things that declare types:

    StorageClass	static, register, volatile, etc.
    Structure	struct, union, enum, etc.

For most colorschemes I've seen, these are all defined to be the same as
Type so most users won't notice.