### PR TITLE
Match end of word on preprocessor directive

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -102,7 +102,7 @@ hi def link	xmlRegion Comment
 syn spell default
 
 " [1] 9.5 Pre-processing directives
-syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)" skip="\\$" end="$" contains=csComment keepend
+syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)\>" skip="\\$" end="$" contains=csComment keepend
 syn region	csRegion	matchgroup=csPreCondit start="^\s*#\s*region.*$" end="^\s*#\s*endregion" transparent fold contains=TOP
 syn region	csSummary	start="^\s*/// <summary" end="^\%\(\s*///\)\@!" transparent fold keepend
 


### PR DESCRIPTION
Fix "#elseif" is highlighted like a valid keyword.

We don't want text after #if (like #ifhaha) to be highlighted as if it
were correct since we don't accept nonsense preprocessor text (like #haha).

This helps catch incorrect use of #elseif instead of #elif.

Directives like #error and #pragma still correctly highlight their
message/argument text.