### PR TITLE
Add csUnicodeNumber to csCharacter

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -120,12 +120,13 @@ syn match	csSpecialError	"\\." contained
 syn match	csSpecialCharError	"[^']" contained
 " [1] 9.4.4.4 Character literals
 syn match	csSpecialChar	+\\["\\'0abfnrtvx]+ contained display
+syn match	csUnicodeNumber	+\\x\x\{2,4}+ contained contains=csUnicodeSpecifier display
 syn match	csUnicodeNumber	+\\u\x\{4}+ contained contains=csUnicodeSpecifier display
 syn match	csUnicodeNumber	+\\U\x\{8}+ contained contains=csUnicodeSpecifier display
 syn match	csUnicodeSpecifier	+\\[uU]+ contained display
 
 syn region	csString	matchgroup=csQuote start=+"+  end=+"+ end=+$+ extend contains=csSpecialChar,csSpecialError,csUnicodeNumber,@Spell
-syn match	csCharacter	"'[^']*'" contains=csSpecialChar,csSpecialCharError display
+syn match	csCharacter	"'[^']*'" contains=csSpecialChar,csSpecialCharError,csUnicodeNumber display
 syn match	csCharacter	"'\\''" contains=csSpecialChar display
 syn match	csCharacter	"'[^\\]'" display
 syn match	csNumber	"\<0[0-7]*[lL]\=\>" display


### PR DESCRIPTION
C# supports these with Strings and Characters:

~~~
\x41
\x041
\x0041
\u0041
~~~

However Vim currently only supports them with Strings, and even then only the
last variant. This commit adds support for the other three to Strings and
Characters. Fixes #16

https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/char