### PR TITLE
Improve escape sequence highlighting

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -119,11 +119,11 @@ syn keyword	csIsAs	is as
 syn match	csSpecialError	"\\." contained
 syn match	csSpecialCharError	"[^']" contained
 " [1] 9.4.4.4 Character literals
-syn match	csSpecialChar	+\\["\\'0abfnrtvx]+ contained display
-syn match	csUnicodeNumber	+\\x\x\{2,4}+ contained contains=csUnicodeSpecifier display
+syn match	csSpecialChar	+\\["\\'0abfnrtv]+ contained display
+syn match	csUnicodeNumber	+\\x\x\{1,4}+ contained contains=csUnicodeSpecifier display
 syn match	csUnicodeNumber	+\\u\x\{4}+ contained contains=csUnicodeSpecifier display
-syn match	csUnicodeNumber	+\\U\x\{8}+ contained contains=csUnicodeSpecifier display
-syn match	csUnicodeSpecifier	+\\[uU]+ contained display
+syn match	csUnicodeNumber	+\\U00\x\{6}+ contained contains=csUnicodeSpecifier display
+syn match	csUnicodeSpecifier	+\\[uUx]+ contained display
 
 syn region	csString	matchgroup=csQuote start=+"+  end=+"+ end=+$+ extend contains=csSpecialChar,csSpecialError,csUnicodeNumber,@Spell
 syn match	csCharacter	"'[^']*'" contains=csSpecialChar,csSpecialCharError,csUnicodeNumber display

--- a/test/chars_and_numbers.vader
+++ b/test/chars_and_numbers.vader
@@ -65,36 +65,53 @@ Execute:
   AssertEqual 'csNumber',                 SyntaxAt(4, 12)
 
 Given cs (valid char literals):
+  '\x1'
   '\x41'
   '\x041'
   '\x0041'
   '\u0041'
+  '\U00000041'
 
 Execute:
-  AssertEqual 'csUnicodeNumber',          SyntaxAt(1, 2)
-  AssertEqual 'csUnicodeNumber',          SyntaxAt(1, 3)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(1, 2)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(1, 3)
   AssertEqual 'csUnicodeNumber',          SyntaxAt(1, 4)
-  AssertEqual 'csUnicodeNumber',          SyntaxAt(2, 2)
-  AssertEqual 'csUnicodeNumber',          SyntaxAt(2, 3)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(2, 2)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(2, 3)
   AssertEqual 'csUnicodeNumber',          SyntaxAt(2, 4)
-  AssertEqual 'csUnicodeNumber',          SyntaxAt(3, 2)
-  AssertEqual 'csUnicodeNumber',          SyntaxAt(3, 3)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(3, 2)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(3, 3)
   AssertEqual 'csUnicodeNumber',          SyntaxAt(3, 4)
   AssertEqual 'csUnicodeSpecifier',       SyntaxAt(4, 2)
   AssertEqual 'csUnicodeSpecifier',       SyntaxAt(4, 3)
   AssertEqual 'csUnicodeNumber',          SyntaxAt(4, 4)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(5, 2)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(5, 3)
+  AssertEqual 'csUnicodeNumber',          SyntaxAt(5, 4)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(6, 2)
+  AssertEqual 'csUnicodeSpecifier',       SyntaxAt(6, 3)
+  AssertEqual 'csUnicodeNumber',          SyntaxAt(6, 4)
+  AssertEqual 'csUnicodeNumber',          SyntaxAt(6, 11)
 
 Given cs (invalid char literals):
   '\xaaaaa'
   '\uaaaaa'
+  '\U00aaaaaaa'
+  '\x'
   '\uaaa'
+  '\U00aaaaa'
   '\xg'
   '\ugggg'
+  '\Ugggggggg'
 
 Execute:
-  AssertEqual 'csSpecialCharError',       SyntaxAt(1, 8), 'More than 4 digits'
-  AssertEqual 'csSpecialCharError',       SyntaxAt(2, 8), 'More than 4 digits (unicode)'
-  AssertEqual 'csSpecialCharError',       SyntaxAt(3, 2), 'Less than 4 digits (unicode)'
-  AssertEqual 'csSpecialCharError',       SyntaxAt(4, 4), 'Non-hex digit'
-  AssertEqual 'csSpecialCharError',       SyntaxAt(5, 4), 'Non-hex digit (unicode)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(1, 8),  'More than 4 digits (\x)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(2, 8),  'More than 4 digits (\u)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(3, 12), 'More than 8 digits (\U)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(4, 2),  'Less than 1 digit (\x)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(5, 2),  'Less than 4 digits (\u)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(6, 2),  'Less than 8 digits (\u)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(7, 4),  'Non-hex digit (\x)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(8, 4),  'Non-hex digit (\u)'
+  AssertEqual 'csSpecialCharError',       SyntaxAt(9, 4),  'Non-hex digit (\U)'
 


### PR DESCRIPTION
G'day Nick,

Your message in the F# issue today reminded me that I'd been meaning to send this small patch.

\x wasn't matched as an escape sequence error and \xF wasn't matching as a valid hex escape.

Also, requiring a couple of zeros after the \U escape as suggested in the [programming guide](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/#string-escape-sequences) seems a helpful addition.

I'm not sure if x in \x should match as csUnicodeSpecifier.  csUnicodeSpecifier is included in the relevant definition but the tests clearly don't expect it.

```vim
syn match csUnicodeNumber +\\x\x\{1,4}+ contained contains=csUnicodeSpecifier display
```

Let me know how you want it to work and I'll add some tests to cover these changes.

Thanks,
Doug
