### PR TITLE
Improve number highlighting

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -129,7 +129,6 @@ syn region	csString	matchgroup=csQuote start=+"+  end=+"+ end=+$+ extend contain
 syn match	csCharacter	"'[^']*'" contains=csSpecialChar,csSpecialCharError,csUnicodeNumber display
 syn match	csCharacter	"'\\''" contains=csSpecialChar display
 syn match	csCharacter	"'[^\\]'" display
-syn match	csNumber	"\<0[0-7]*[lL]\=\>" display
 syn match	csNumber	"\<0[xX][[:xdigit:]_]\+[lL]\=\>" display
 syn match	csNumber	"\<0[bB][01_]\+[lL]\=\>" display
 syn match	csNumber	"\<[[:digit:]_]\+[lL]\=\>" display

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -129,20 +129,25 @@ syn region	csString	matchgroup=csQuote start=+"+  end=+"+ end=+$+ extend contain
 syn match	csCharacter	"'[^']*'" contains=csSpecialChar,csSpecialCharError,csUnicodeNumber display
 syn match	csCharacter	"'\\''" contains=csSpecialChar display
 syn match	csCharacter	"'[^\\]'" display
-syn match	csNumber	"\<0[xX][[:xdigit:]_]\+[lL]\=\>" display
-syn match	csNumber	"\<0[bB][01_]\+[lL]\=\>" display
-syn match	csNumber	"\<[[:digit:]_]\+[lL]\=\>" display
-syn match	csNumber	"\<[[:digit:]_]\+\.[[:digit:]_]*\%\([eE][-+]\=[[:digit:]_]\+\)\=[fFdDmM]\=" display
-syn match	csNumber	"\.[[:digit:]_]\+\%\([eE][-+]\=[[:digit:]_]\+\)\=[fFdDmM]\=" display
-syn match	csNumber	"\<[[:digit:]_]\+[eE][-+]\=[[:digit:]_]\+[fFdDmM]\=\>" display
-syn match	csNumber	"\<[[:digit:]_]\+\%\([eE][-+]\=[[:digit:]_]\+\)\=[fFdDmM]\>" display
+
+" Numbers
+syn case	ignore
+syn match	csInteger	"\<0b[01_]*[01]\%([lu]\|lu\|ul\)\=\>" display
+syn match	csInteger	"\<\d\+\%(_\+\d\+\)*\%([lu]\|lu\|ul\)\=\>" display
+syn match	csInteger	"\<0x[[:xdigit:]_]*\x\%([lu]\|lu\|ul\)\=\>" display
+syn match	csReal	"\<\d\+\%(_\+\d\+\)*\.\d\+\%(_\+\d\+\)*\%\(e[-+]\=\d\+\%(_\+\d\+\)*\)\=[fdm]\=" display
+syn match	csReal	"\.\d\+\%(_\+\d\+\)*\%(e[-+]\=\d\+\%(_\+\d\+\)*\)\=[fdm]\=\>" display
+syn match	csReal	"\<\d\+\%(_\+\d\+\)*e[-+]\=\d\+\%(_\+\d\+\)*[fdm]\=\>" display
+syn match	csReal	"\<\d\+\%(_\+\d\+\)*[fdm]\>" display
+syn case	match
+syn cluster     csNumber	contains=csInteger,csReal
 
 syn region	csInterpolatedString	matchgroup=csQuote start=+\$"+ end=+"+ extend contains=csInterpolation,csEscapedInterpolation,csSpecialChar,csSpecialError,csUnicodeNumber,@Spell
 
 syn region	csInterpolation	matchgroup=csInterpolationDelimiter start=+{+ end=+}+ keepend contained contains=@csAll,csBraced,csBracketed,csInterpolationAlign,csInterpolationFormat
 syn match	csEscapedInterpolation	"{{" transparent contains=NONE display
 syn match	csEscapedInterpolation	"}}" transparent contains=NONE display
-syn region	csInterpolationAlign	matchgroup=csInterpolationAlignDel start=+,+ end=+}+ end=+:+me=e-1 contained contains=csNumber,csConstant,csCharacter,csParens,csOpSymbols,csString,csBracketed display
+syn region	csInterpolationAlign	matchgroup=csInterpolationAlignDel start=+,+ end=+}+ end=+:+me=e-1 contained contains=@csNumber,csConstant,csCharacter,csParens,csOpSymbols,csString,csBracketed display
 syn match	csInterpolationFormat	+:[^}]\+}+ contained contains=csInterpolationFormatDel display
 syn match	csInterpolationAlignDel	+,+ contained display
 syn match	csInterpolationFormatDel	+:+ contained display
@@ -156,7 +161,7 @@ syn region	csInterVerbString	matchgroup=csQuote start=+\$@"+ end=+"+ skip=+""+ e
 syn region	csBracketed	matchgroup=csParens start=+(+ end=+)+ extend contained transparent contains=@csAll,csBraced,csBracketed
 syn region	csBraced	matchgroup=csParens start=+{+ end=+}+ extend contained transparent contains=@csAll,csBraced,csBracketed
 
-syn cluster	csAll	contains=csCharacter,csClassType,csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csConstant,csNumber,csOpSymbols,csOperatorError,csParens,csPreCondit,csRegion,csString,csSummary,csType,csUnicodeNumber,csUnicodeSpecifier,csInterpolatedString,csVerbatimString,csInterVerbString,csUserType,csUserIdentifier,csUserInterface,csUserMethod
+syn cluster	csAll	contains=csCharacter,csClassType,csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csConstant,@csNumber,csOpSymbols,csOperatorError,csParens,csPreCondit,csRegion,csString,csSummary,csType,csUnicodeNumber,csUnicodeSpecifier,csInterpolatedString,csVerbatimString,csInterVerbString,csUserType,csUserIdentifier,csUserInterface,csUserMethod
 
 " The default highlighting.
 hi def link	csType	Type
@@ -200,7 +205,8 @@ hi def link	csVerbatimQuote	SpecialChar
 hi def link	csPreCondit	PreCondit
 hi def link	csCharacter	Character
 hi def link	csSpecialChar	SpecialChar
-hi def link	csNumber	Number
+hi def link	csInteger	Number
+hi def link	csReal	Float
 hi def link	csUnicodeNumber	SpecialChar
 hi def link	csUnicodeSpecifier	SpecialChar
 hi def link	csInterpolationDelimiter	Delimiter

--- a/test/chars_and_numbers.vader
+++ b/test/chars_and_numbers.vader
@@ -14,30 +14,52 @@ Execute:
 Given cs (decimal literals):
   1234
   1234l
+  1234u
+  1234ul
+  1234lu
 
 Execute:
-  AssertEqual 'csNumber',                 SyntaxAt(1, 1)
-  AssertEqual 'csNumber',                 SyntaxAt(2, 5)
+  AssertEqual 'csInteger',                SyntaxAt(1, 1)
+  AssertEqual 'csInteger',                SyntaxAt(2, 5)
+  AssertEqual 'csInteger',                SyntaxAt(3, 5)
+  AssertEqual 'csInteger',                SyntaxAt(4, 6)
+  AssertEqual 'csInteger',                SyntaxAt(5, 6)
 
-Given cs (hex literal):
+Given cs (hex literals):
   0xf
+  0Xf
   0xfl
+  0xfu
+  0xful
+  0xflu
   0xg
 
 Execute:
-  AssertEqual 'csNumber',                 SyntaxAt(1, 3)
-  AssertEqual 'csNumber',                 SyntaxAt(2, 4)
-  AssertNotEqual 'csNumber',              SyntaxAt(3, 3), 'Not a hex digit'
+  AssertEqual 'csInteger',                SyntaxAt(1, 3)
+  AssertEqual 'csInteger',                SyntaxAt(2, 3)
+  AssertEqual 'csInteger',                SyntaxAt(3, 4)
+  AssertEqual 'csInteger',                SyntaxAt(4, 4)
+  AssertEqual 'csInteger',                SyntaxAt(5, 5)
+  AssertEqual 'csInteger',                SyntaxAt(6, 5)
+  AssertNotEqual 'csInteger',             SyntaxAt(7, 3), 'Not a hex digit'
 
-Given cs (binary literal):
+Given cs (binary literals):
   0b0
-  0B0L
+  0B0
+  0b0l
+  0b0u
+  0b0ul
+  0b0lu
   0b2
 
 Execute:
-  AssertEqual 'csNumber',                 SyntaxAt(1, 3)
-  AssertEqual 'csNumber',                 SyntaxAt(2, 4)
-  AssertNotEqual 'csNumber',              SyntaxAt(3, 3), 'Not a binary digit'
+  AssertEqual 'csInteger',                SyntaxAt(1, 3)
+  AssertEqual 'csInteger',                SyntaxAt(2, 3)
+  AssertEqual 'csInteger',                SyntaxAt(3, 4)
+  AssertEqual 'csInteger',                SyntaxAt(4, 4)
+  AssertEqual 'csInteger',                SyntaxAt(5, 5)
+  AssertEqual 'csInteger',                SyntaxAt(6, 5)
+  AssertNotEqual 'csInteger',             SyntaxAt(7, 3), 'Not a binary digit'
 
 Given cs (floating point literals):
   1.5f
@@ -46,23 +68,25 @@ Given cs (floating point literals):
   123.456M
 
 Execute:
-  AssertEqual 'csNumber',                 SyntaxAt(1, 4)
-  AssertEqual 'csNumber',                 SyntaxAt(2, 5)
-  AssertEqual 'csNumber',                 SyntaxAt(3, 8)
-  AssertEqual 'csNumber',                 SyntaxAt(4, 8)
+  AssertEqual 'csReal',                   SyntaxAt(1, 4)
+  AssertEqual 'csReal',                   SyntaxAt(2, 5)
+  AssertEqual 'csReal',                   SyntaxAt(3, 8)
+  AssertEqual 'csReal',                   SyntaxAt(4, 8)
 
 Given cs (digit separators):
   123_456
+  123__456
   0x_be_af
   0b_0011_0101
   123_456.242_3D
 
 Execute:
-  AssertEqual 'csNumber',                 SyntaxAt(1, 4)
-  AssertEqual 'csNumber',                 SyntaxAt(2, 3)
-  AssertEqual 'csNumber',                 SyntaxAt(3, 3)
-  AssertEqual 'csNumber',                 SyntaxAt(4, 4)
-  AssertEqual 'csNumber',                 SyntaxAt(4, 12)
+  AssertEqual 'csInteger',                SyntaxAt(1, 4)
+  AssertEqual 'csInteger',                SyntaxAt(2, 5)
+  AssertEqual 'csInteger',                SyntaxAt(3, 3)
+  AssertEqual 'csInteger',                SyntaxAt(4, 3)
+  AssertEqual 'csReal',                   SyntaxAt(5, 4)
+  AssertEqual 'csReal',                   SyntaxAt(5, 12)
 
 Given cs (valid char literals):
   '\x41'


### PR DESCRIPTION
This adds support for `ul` and `lu` integer suffixes and disallows invalid use of `_` in number literals.

I've added some error highlighting for the simple cases of leading and trailing underscores.  I could add more thorough error matching if you wish.

I was going to split integers and reals into different syntax groups and link the latter to the Float highlight group but thought you may have grouped them together intentionally.  This would also make expanding the underscore errror highlighting a bit simpler.

I also removed the octal literal highlighting as that's not supported by C#.  It looks like it's been there since the first versions of this syntax file.
