### PR TITLE
Improve typeof operand highlighting (WIP)

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -45,8 +45,9 @@ syn match	csContextualStatement	/\<\%(get\|set\)\s*=>/me=s+3
 syn match	csContextualStatement	/\<where\>[^:]\+:/me=s+5
 
 " Operators
-syn keyword	csTypeOf	typeof contained
-syn region	csTypeOfStatement	start="typeof(" end=")" contains=csType, csTypeOf
+syn keyword	csTypeOf	typeof nextgroup=csTypeOfOperand,csTypeOfError skipwhite skipempty
+syn region	csTypeOfOperand	matchgroup=csParens start="(" end=")" contains=csType
+syn match       csTypeOfError               "[^([:space:]]" contained
 
 " Punctuation
 syn match	csBraces	"[{}\[\]]" display
@@ -172,7 +173,8 @@ hi def link	csModifier	StorageClass
 hi def link	csConstant	Constant
 hi def link	csException	Exception
 hi def link	csTypeOf	Keyword
-hi def link	csTypeOfStatement	Typedef
+hi def link	csTypeOfOperand	Typedef
+hi def link	csTypeOfError	Error
 hi def link	csUnspecifiedStatement	Statement
 hi def link	csUnsupportedStatement	Statement
 hi def link	csUnspecifiedKeyword	Keyword


### PR DESCRIPTION
Currently the `typeof` operand and parens are all matched as `csTypeofStatement`.

This looks very odd to my eye.  I'd expect the parens to be in the default foreground colour and wouldn't expect the operand to get special treatment either beyond the normal type highlighting.

Someone has obviously gone to some trouble to implement this behaviour though so I may be missing something obvious.  See: https://github.com/nickspoons/vim-cs/commit/5ffc8074b7fe062bea573cc648cde8d717997a38

The paren is also currently required to immediately follow the keyword which I assume is just a bug.

This commit allows the following paren with intervening whitespace (including empty lines which is probably overkill) and marks anything following it that's not an opening paren as an error.  It matches the parens as the default paren group (csParens) and highlights the operand specially as is currently done.

Personally, I'd probably just go with the following which highlights the operand type normally.

```vim
syn keyword csTypeOf        typeof nextgroup=csTypeOfOperand skipwhite
syn region  csTypeOfOperand matchgroup=csParens start="(" end=")" transparent contains=csType
```
