### PR TITLE
Allow @$" to open interpolated verbatim strings

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -150,9 +150,8 @@ syn match	csInterpolationFormatDel	+:+ contained display
 
 syn region	csVerbatimString	matchgroup=csQuote start=+@"+ end=+"+ skip=+""+ extend contains=csVerbatimQuote,@Spell
 syn match	csVerbatimQuote	+""+ contained
-syn match	csQuoteError	+@$"+he=s+2,me=s+2
 
-syn region	csInterVerbString	matchgroup=csQuote start=+\$@"+ end=+"+ skip=+""+ extend contains=csInterpolation,csEscapedInterpolation,csSpecialChar,csSpecialError,csUnicodeNumber,csVerbatimQuote,@Spell
+syn region	csInterVerbString	matchgroup=csQuote start=+$@"+ start=+@$"+ end=+"+ skip=+""+ extend contains=csInterpolation,csEscapedInterpolation,csSpecialChar,csSpecialError,csUnicodeNumber,csVerbatimQuote,@Spell
 
 syn region	csBracketed	matchgroup=csParens start=+(+ end=+)+ extend contained transparent contains=@csAll,csBraced,csBracketed
 syn region	csBraced	matchgroup=csParens start=+{+ end=+}+ extend contained transparent contains=@csAll,csBraced,csBracketed
@@ -193,7 +192,6 @@ hi def link	csSpecialError	Error
 hi def link	csSpecialCharError	Error
 hi def link	csString	String
 hi def link	csQuote	String
-hi def link	csQuoteError	Error
 hi def link	csInterpolatedString	String
 hi def link	csVerbatimString	String
 hi def link	csInterVerbString	String

--- a/test/strings.vader
+++ b/test/strings.vader
@@ -341,11 +341,11 @@ Execute:
   AssertEqual 'csVerbatimQuote',              SyntaxAt(2, 5)
   AssertEqual 'csQuote',                      SyntaxAt(2, 6)
 
-Given cs (an incorrect prefix (@$ instead of $@)):
-  @$""
+Given cs (a verbatim, interpolated string with alternate open delimiter (@$ instead of $@)):
+  @$"..."
 
 Execute:
-  AssertEqual 'csQuoteError',             SyntaxAt(1)
-  AssertEqual 'csQuoteError',             SyntaxAt(2)
+  AssertEqual 'csQuote',                  SyntaxAt(1)
+  AssertEqual 'csQuote',                  SyntaxAt(2)
   AssertEqual 'csQuote',                  SyntaxAt(3)
-  AssertEqual 'csQuote',                  SyntaxAt(4)
+  AssertEqual 'csInterVerbString',        SyntaxAt(4)


### PR DESCRIPTION
Both `$@"` and `@$"` have been supported as opening delimiters for interpolated verbatim strings since version 8.0.

As there's no obvious feature versioning in the syntax file I'm assuming we just want to support the latest version so I removed the error highlighting for earlier versions as well.
