### PR TITLE
Constrain csTypeOfOperand to typeof expressions

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -46,7 +46,7 @@ syn match	csContextualStatement	/\<where\>[^:]\+:/me=s+5
 
 " Operators
 syn keyword	csTypeOf	typeof nextgroup=csTypeOfOperand,csTypeOfError skipwhite skipempty
-syn region	csTypeOfOperand	matchgroup=csParens start="(" end=")" contains=csType
+syn region	csTypeOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
 syn match       csTypeOfError               "[^([:space:]]" contained
 
 " Punctuation

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -70,3 +70,28 @@ Execute:
   AssertEqual 'csGenericBraces', SyntaxAt()
   normal! f>
   AssertEqual 'csGenericBraces', SyntaxAt()
+
+Given cs (typeof operator):
+  typeof(Dictionary<string,List<Image>>)
+
+Execute:
+  AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
+  AssertEqual 'csParens',         SyntaxAt(1, 7)
+  AssertEqual 'csTypeOfOperand',  SyntaxAt(1, 8)
+  AssertEqual 'csParens',         SyntaxAt(1, 38)
+
+Given cs (typeof operator with space before open paren):
+  typeof (Dictionary<string,List<Image>>)
+
+Execute:
+  AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
+  AssertEqual 'csParens',         SyntaxAt(1, 8)
+  AssertEqual 'csTypeOfOperand',  SyntaxAt(1, 9)
+  AssertEqual 'csParens',         SyntaxAt(1, 39)
+
+Given cs (typeof operator with missing operand parens):
+  typeof Dictionary<string,List<Image>>
+
+Execute:
+  AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
+  AssertEqual 'csTypeOfError',    SyntaxAt(1, 8)


### PR DESCRIPTION
This fixes `csTypeOfOperand` matching at the top level and adds some tests for highlighting of `typeof` expressions.
