### PR TITLE
Allow whitespace in auto-implemented property definitions

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -42,6 +42,8 @@ syn match	csContextualStatement	/\<yield[[:space:]\n]\+\%(return\|break\)/me=s+5
 syn match	csContextualStatement	/\<partial[[:space:]\n]\+\%(class\|struct\|interface\)/me=s+7
 syn match	csContextualStatement	/\<\%(get\|set\)\%(\s*;\|[[:space:]\n]*{\)/me=s+3
 syn match	csContextualStatement	/\<\%(get\|set\)\s*=>/me=s+3
+syn match	csContextualStatement	/\<init\%(\s*;\|[[:space:]\n]*{\)/me=s+4
+syn match	csContextualStatement	/\<init\s*=>/me=s+4
 syn match	csContextualStatement	/\<where\>[^:]\+:/me=s+5
 
 " Operators

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -40,7 +40,7 @@ syn keyword	csUnspecifiedKeyword	explicit implicit
 " Contextual Keywords
 syn match	csContextualStatement	/\<yield[[:space:]\n]\+\%(return\|break\)/me=s+5
 syn match	csContextualStatement	/\<partial[[:space:]\n]\+\%(class\|struct\|interface\)/me=s+7
-syn match	csContextualStatement	/\<\%(get\|set\)\%(;\|[[:space:]\n]*{\)/me=s+3
+syn match	csContextualStatement	/\<\%(get\|set\)\%(\s*;\|[[:space:]\n]*{\)/me=s+3
 syn match	csContextualStatement	/\<\%(get\|set\)\s*=>/me=s+3
 syn match	csContextualStatement	/\<where\>[^:]\+:/me=s+5
 

--- a/test/properties.vader
+++ b/test/properties.vader
@@ -8,12 +8,31 @@ Execute:
   AssertEqual 'csContextualStatement', SyntaxAt()
 
 
+Given cs (standard get/init formatting):
+  get { return 0; }
+  init { _value = value; }
+
+Execute:
+  AssertEqual 'csContextualStatement', SyntaxAt()
+  normal! j
+  AssertEqual 'csContextualStatement', SyntaxAt()
+
+
 Given cs (automatic property get/set):
   get; set;
 
 Execute:
   AssertEqual 'csContextualStatement', SyntaxAt()
   normal! fs
+  AssertEqual 'csContextualStatement', SyntaxAt()
+
+
+Given cs (automatic property get/init):
+  get; init;
+
+Execute:
+  AssertEqual 'csContextualStatement', SyntaxAt()
+  normal! fi
   AssertEqual 'csContextualStatement', SyntaxAt()
 
 
@@ -26,10 +45,28 @@ Execute:
   AssertEqual 'csContextualStatement', SyntaxAt()
 
 
+Given cs (automatic property get/init with whitespace):
+  get ; init ;
+
+Execute:
+  AssertEqual 'csContextualStatement', SyntaxAt()
+  normal! fi
+  AssertEqual 'csContextualStatement', SyntaxAt()
+
+
 Given cs (in-line property get/set):
   get => 0; set => _value = value;
 
 Execute:
   AssertEqual 'csContextualStatement', SyntaxAt()
   normal! fs
+  AssertEqual 'csContextualStatement', SyntaxAt()
+
+
+Given cs (in-line property get/init):
+  get => 0; init => _value = value;
+
+Execute:
+  AssertEqual 'csContextualStatement', SyntaxAt()
+  normal! fi
   AssertEqual 'csContextualStatement', SyntaxAt()

--- a/test/properties.vader
+++ b/test/properties.vader
@@ -17,6 +17,15 @@ Execute:
   AssertEqual 'csContextualStatement', SyntaxAt()
 
 
+Given cs (automatic property get/set with whitespace):
+  get ; set ;
+
+Execute:
+  AssertEqual 'csContextualStatement', SyntaxAt()
+  normal! fs
+  AssertEqual 'csContextualStatement', SyntaxAt()
+
+
 Given cs (in-line property get/set):
   get => 0; set => _value = value;
 


### PR DESCRIPTION
Allow whitespace before the following semicolon when matching get/set.

E.g. { get ; set ; }

Also match the newish `init` keyword introduced in 9.0.
