### PR TITLE
Improve preprocessor directive highlighting

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -73,8 +73,9 @@ syn region	csGeneric	matchgroup=csGenericBraces start="<" end=">" oneline contai
 "
 " PROVIDES: @csCommentHook
 syn keyword	csTodo	contained TODO FIXME XXX NOTE HACK TBD
-syn region	csComment	start="/\*"  end="\*/" contains=@csCommentHook,csTodo,@Spell
-syn match	csComment	"//.*$" contains=@csCommentHook,csTodo,@Spell
+syn region	csBlockComment	start="/\*"  end="\*/" contains=@csCommentHook,csTodo,@Spell
+syn match	csLineComment	"//.*$" contains=@csCommentHook,csTodo,@Spell
+syn cluster	csComment	contains=csLineComment,csBlockComment
 
 " xml markup inside '///' comments
 syn cluster	xmlRegionHook	add=csXmlCommentLeader
@@ -102,7 +103,7 @@ hi def link	xmlRegion Comment
 syn spell default
 
 " [1] 9.5 Pre-processing directives
-syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)\>" skip="\\$" end="$" contains=csComment keepend
+syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)\>" skip="\\$" end="$" contains=csLineComment keepend
 syn region	csRegion	matchgroup=csPreCondit start="^\s*#\s*region.*$" end="^\s*#\s*endregion" transparent fold contains=TOP
 syn region	csSummary	start="^\s*/// <summary" end="^\%\(\s*///\)\@!" transparent fold keepend
 
@@ -161,7 +162,7 @@ syn region	csInterVerbString	matchgroup=csQuote start=+$@"+ start=+@$"+ end=+"+ 
 syn region	csBracketed	matchgroup=csParens start=+(+ end=+)+ extend contained transparent contains=@csAll,csBraced,csBracketed
 syn region	csBraced	matchgroup=csParens start=+{+ end=+}+ extend contained transparent contains=@csAll,csBraced,csBracketed
 
-syn cluster	csAll	contains=csCharacter,csClassType,csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csConstant,@csNumber,csOpSymbols,csOperatorError,csParens,csPreCondit,csRegion,csString,csSummary,csType,csUnicodeNumber,csUnicodeSpecifier,csInterpolatedString,csVerbatimString,csInterVerbString,csUserType,csUserIdentifier,csUserInterface,csUserMethod
+syn cluster	csAll	contains=csCharacter,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csConstant,@csNumber,csOpSymbols,csOperatorError,csParens,csPreCondit,csRegion,csString,csSummary,csType,csUnicodeNumber,csUnicodeSpecifier,csInterpolatedString,csVerbatimString,csInterVerbString,csUserType,csUserIdentifier,csUserInterface,csUserMethod
 
 " The default highlighting.
 hi def link	csType	Type
@@ -190,6 +191,8 @@ hi def link	csOperatorError	Error
 
 hi def link	csTodo	Todo
 hi def link	csComment	Comment
+hi def link	csLineComment	csComment
+hi def link	csBlockComment	csComment
 
 hi def link	csOpSymbols	Operator
 hi def link	csLogicSymbols	Operator

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -108,8 +108,9 @@ syn region	csPreProcConditional	start="^\s*\zs#\s*\%(if\|elif\)\>" end="$" conta
 syn region	csPreProcConditional	start="^\s*\zs#\s*\%(else\|endif\)\>" end="$" contains=csLineComment keepend
 syn region	csPreProcLine	start="^\s*\zs#\s*line\>" end="$" contains=csLineComment keepend
 syn region	csPreProcDiagnostic	start="^\s*\zs#\s*\%(error\|warning\)\>" end="$"
-syn region	csPreProcConditionalSection	matchgroup=csPreProcRegion start="^\s*\zs#\s*region\>.*" end="^\s*#\s*endregion\>.*" transparent fold contains=TOP
+syn region	csPreProcConditionalSection	matchgroup=csPreProcRegion start="^\s*#\s*region\>.*" end="^\s*#\s*endregion\>.*" transparent fold contains=TOP
 syn region	csPreProcPragma	start="^\s*\zs#\s*pragma\>" end="$" contains=csLineComment keepend
+syn region	csPreProcNullable	start="^\s*\zs#\s*nullable\>" end="$" contains=csLineComment keepend
 
 syn region	csSummary	start="^\s*/// <summary" end="^\%\(\s*///\)\@!" transparent fold keepend
 
@@ -217,8 +218,9 @@ hi def link	csPreProcDeclaration	Define
 hi def link	csPreProcConditional	PreCondit
 hi def link	csPreProcLine	csPreProc
 hi def link	csPreProcDiagnostic	csPreProc
-hi def link	csPreProcPragma	csPreProc
 hi def link	csPreProcRegion	csPreProc
+hi def link	csPreProcPragma	csPreProc
+hi def link	csPreProcNullable	csPreProc
 
 hi def link	csCharacter	Character
 hi def link	csSpecialChar	SpecialChar

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -103,8 +103,14 @@ hi def link	xmlRegion Comment
 syn spell default
 
 " [1] 9.5 Pre-processing directives
-syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)\>" end="$" contains=csLineComment keepend
-syn region	csRegion	matchgroup=csPreCondit start="^\s*#\s*region.*$" end="^\s*#\s*endregion" transparent fold contains=TOP
+syn region	csPreProcDeclaration	start="^\s*\zs#\s*\%(define\|undef\)\>" end="$" contains=csLineComment keepend
+syn region	csPreProcConditional	start="^\s*\zs#\s*\%(if\|elif\)\>" end="$" contains=csLineComment keepend
+syn region	csPreProcConditional	start="^\s*\zs#\s*\%(else\|endif\)\>" end="$" contains=csLineComment keepend
+syn region	csPreProcLine	start="^\s*\zs#\s*line\>" end="$" contains=csLineComment keepend
+syn region	csPreProcDiagnostic	start="^\s*\zs#\s*\%(error\|warning\)\>" end="$"
+syn region	csPreProcConditionalSection	matchgroup=csPreProcRegion start="^\s*\zs#\s*region\>.*" end="^\s*#\s*endregion\>.*" transparent fold contains=TOP
+syn region	csPreProcPragma	start="^\s*\zs#\s*pragma\>" end="$" contains=csLineComment keepend
+
 syn region	csSummary	start="^\s*/// <summary" end="^\%\(\s*///\)\@!" transparent fold keepend
 
 
@@ -205,7 +211,15 @@ hi def link	csInterpolatedString	String
 hi def link	csVerbatimString	String
 hi def link	csInterVerbString	String
 hi def link	csVerbatimQuote	SpecialChar
-hi def link	csPreCondit	PreCondit
+
+hi def link     csPreProc	PreProc
+hi def link	csPreProcDeclaration	Define
+hi def link	csPreProcConditional	PreCondit
+hi def link	csPreProcLine	csPreProc
+hi def link	csPreProcDiagnostic	csPreProc
+hi def link	csPreProcPragma	csPreProc
+hi def link	csPreProcRegion	csPreProc
+
 hi def link	csCharacter	Character
 hi def link	csSpecialChar	SpecialChar
 hi def link	csInteger	Number

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -103,7 +103,7 @@ hi def link	xmlRegion Comment
 syn spell default
 
 " [1] 9.5 Pre-processing directives
-syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)\>" skip="\\$" end="$" contains=csLineComment keepend
+syn region	csPreCondit	start="^\s*#\s*\%(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\|pragma\)\>" end="$" contains=csLineComment keepend
 syn region	csRegion	matchgroup=csPreCondit start="^\s*#\s*region.*$" end="^\s*#\s*endregion" transparent fold contains=TOP
 syn region	csSummary	start="^\s*/// <summary" end="^\%\(\s*///\)\@!" transparent fold keepend
 

--- a/test/preprocessors.vader
+++ b/test/preprocessors.vader
@@ -114,3 +114,12 @@ Execute:
   AssertEqual 'csPreProcPragma',        SyntaxAt(1, 17)
   AssertEqual 'csLineComment',          SyntaxAt(1, 37)
 
+Given cs (#nullable with comment):
+  #nullable disable annotations // nullable
+
+Execute:
+  AssertEqual 'csPreProcNullable',      SyntaxAt(1, 1)
+  AssertEqual 'csPreProcNullable',      SyntaxAt(1, 11)
+  AssertEqual 'csPreProcNullable',      SyntaxAt(1, 19)
+  AssertEqual 'csLineComment',          SyntaxAt(1, 31)
+

--- a/test/preprocessors.vader
+++ b/test/preprocessors.vader
@@ -1,4 +1,7 @@
-" Unfortunately we can't test preprocessors (#if, #define, #pragma, #region
-" etc.) with Vader because the plugin treats any line beginning with "#" as a
-" comment and ignores it:
-" https://github.com/junegunn/vader.vim#comments
+Given cs (preprocessor define with line comment):
+  #define FOOBAR // foobar defined
+
+Execute:
+  AssertEqual 'csPreCondit',   SyntaxAt(1, 1)
+  AssertEqual 'csPreCondit',   SyntaxAt(1, 9)
+  AssertEqual 'csLineComment', SyntaxAt(1, 11)

--- a/test/preprocessors.vader
+++ b/test/preprocessors.vader
@@ -1,7 +1,116 @@
-Given cs (preprocessor define with line comment):
-  #define FOOBAR // foobar defined
+Given cs (#define with comment):
+  #define FOOBAR // define
 
 Execute:
-  AssertEqual 'csPreCondit',   SyntaxAt(1, 1)
-  AssertEqual 'csPreCondit',   SyntaxAt(1, 9)
-  AssertEqual 'csLineComment', SyntaxAt(1, 11)
+  AssertEqual 'csPreProcDeclaration', SyntaxAt(1, 1)
+  AssertEqual 'csPreProcDeclaration', SyntaxAt(1, 9)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 16)
+
+Given cs (#undef with comment):
+  #undef FOOBAR // undef
+
+Execute:
+  AssertEqual 'csPreProcDeclaration', SyntaxAt(1, 1)
+  AssertEqual 'csPreProcDeclaration', SyntaxAt(1, 8)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 15)
+
+Given cs (indented #define):
+      #define FOOBAR
+
+Execute:
+  AssertEqual '',                     SyntaxAt(1, 1)
+  AssertEqual 'csPreProcDeclaration', SyntaxAt(1, 5)
+  AssertEqual 'csPreProcDeclaration', SyntaxAt(1, 13)
+
+Given cs (#if with comments):
+  #if FOO   // if
+      Console.WriteLine("FOO")
+  #elif BAR // elif
+      Console.WriteLine("BAR")
+  #else     // else
+      Console.WriteLine("BAZ")
+  #endif    // endif
+
+Execute:
+  AssertEqual 'csPreProcConditional', SyntaxAt(1, 1)
+  AssertEqual 'csPreProcConditional', SyntaxAt(1, 5)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 11)
+  AssertEqual 'csString',             SyntaxAt(2, 24)
+  AssertEqual 'csPreProcConditional', SyntaxAt(3, 1)
+  AssertEqual 'csPreProcConditional', SyntaxAt(3, 7)
+  AssertEqual 'csLineComment',        SyntaxAt(3, 11)
+  AssertEqual 'csString',             SyntaxAt(4, 24)
+  AssertEqual 'csPreProcConditional', SyntaxAt(5, 1)
+  AssertEqual 'csLineComment',        SyntaxAt(5, 11)
+  AssertEqual 'csString',             SyntaxAt(6, 24)
+  AssertEqual 'csPreProcConditional', SyntaxAt(7, 1)
+  AssertEqual 'csLineComment',        SyntaxAt(7, 11)
+
+Given cs (#line with line number and comment):
+  #line 42 // line
+
+Execute:
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 1)
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 7)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 10)
+
+Given cs (#line with line number and filename):
+  #line 42 "meaning.cs" // line
+
+Execute:
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 1)
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 7)
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 10)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 23)
+
+Given cs (#line with comment):
+  #line default // line
+
+Execute:
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 1)
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 7)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 15)
+
+Given cs (#line with comment):
+  #line hidden // error
+
+Execute:
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 1)
+  AssertEqual 'csPreProcLine',        SyntaxAt(1, 7)
+  AssertEqual 'csLineComment',        SyntaxAt(1, 14)
+
+Given cs (#error):
+  #error This is the end
+
+Execute:
+  AssertEqual 'csPreProcDiagnostic',  SyntaxAt(1, 1)
+  AssertEqual 'csPreProcDiagnostic',  SyntaxAt(1, 8)
+
+Given cs (#warning):
+  #warning The end is nigh
+
+Execute:
+  AssertEqual 'csPreProcDiagnostic',  SyntaxAt(1, 1)
+  AssertEqual 'csPreProcDiagnostic',  SyntaxAt(1, 10)
+
+Given cs (#region):
+  #region enter region
+      Console.WriteLine("Region")
+  #endregion exit region
+
+Execute:
+  AssertEqual 'csPreProcRegion',      SyntaxAt(1, 1)
+  AssertEqual 'csPreProcRegion',      SyntaxAt(1, 9)
+  AssertEqual 'csString',             SyntaxAt(2, 24)
+  AssertEqual 'csPreProcRegion',      SyntaxAt(3, 1)
+  AssertEqual 'csPreProcRegion',      SyntaxAt(3, 12)
+
+Given cs (#pragma with comment):
+  #pragma warning disable 414, CS3021 // pragma
+
+Execute:
+  AssertEqual 'csPreProcPragma',        SyntaxAt(1, 1)
+  AssertEqual 'csPreProcPragma',        SyntaxAt(1, 9)
+  AssertEqual 'csPreProcPragma',        SyntaxAt(1, 17)
+  AssertEqual 'csLineComment',          SyntaxAt(1, 37)
+


### PR DESCRIPTION
- Disallow block comments after preproc directives
- Disallow backslash line continuations in preproc directives
- Exclude line comments from #error, #message, #region directives
- Highlight #nullable preproc directives

These could be refined further and there's probably some value in restricting
directives to valid values.  E.g., matching `#nullable disable` but not
`#nullable disabled`.  I'll look at adding that at a later time.
