### PR TITLE
Highlight nint and nuint types

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -19,6 +19,7 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 syn keyword	csType	bool byte char decimal double float int long object sbyte short string T uint ulong ushort var void dynamic
+syn keyword	csType	nint nuint " contextual
 syn keyword	csStorage	delegate enum interface namespace struct
 syn keyword	csRepeat	break continue do for foreach goto return while
 syn keyword	csConditional	else if switch

--- a/test/types.vader
+++ b/test/types.vader
@@ -1,0 +1,9 @@
+Given cs (nint and nuint):
+  nint foo = 42;
+  nuint foo = 42;
+
+Execute:
+  AssertEqual 'csType', SyntaxAt(1, 1)
+  AssertEqual 'csType', SyntaxAt(2, 1)
+
+


### PR DESCRIPTION
These are contextual keywords but unlikely to cause too many erroneous matches
in the wild so I've just added them as top level keywords for now.

There's precedence with `var`, for example.
