### PR TITLE
Improve categorisation of modifier keywords (WIP)

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -28,22 +28,32 @@ syn match	csOperatorError	display +::+
 syn match	csGlobal	display +global::+
 " user labels (see [1] 8.6 Statements)
 syn match	csLabel	display +^\s*\I\i*\s*:\%([^:]\)\@=+
-syn keyword	csModifier	abstract const internal override private protected public readonly sealed static virtual volatile
-syn match	csModifier	"\<extern\>"
+
+" Modifiers
+syn keyword	csAccessModifier	internal private protected public
+" TODO: in new out
+syn keyword	csModifier	abstract const event override readonly sealed static virtual volatile
+syn match	csModifier	"\<\%(extern\|unsafe\)\>"
+syn match	csModifier	"\<partial\ze\_s\+\%(class\|struct\|interface\|record\|void\)\>"
+
 syn keyword	csException	try catch finally throw when
 syn keyword	csLinq	ascending by descending equals from group in into join let on orderby select where
-syn keyword	csAsync	async await
+
+" Async
+syn keyword	csAsyncModifier	async
+syn keyword	csAsyncOperator	await
 
 syn match	csStorage	"\<extern\ze\s\+alias\>"
 syn match	csStorage	"\%(\<extern\s\+\)\@16<=alias\>"
 
-syn keyword	csUnspecifiedStatement	as base checked event fixed in is lock nameof operator out params ref sizeof stackalloc this unchecked unsafe using
+syn match	csUnsafeStatement	"\<unsafe\ze\_s*{"
+
+syn keyword	csUnspecifiedStatement	as base checked fixed in is lock nameof operator out params ref sizeof stackalloc this unchecked using
 syn keyword	csUnsupportedStatement	value
 syn keyword	csUnspecifiedKeyword	explicit implicit
 
 " Contextual Keywords
 syn match	csContextualStatement	"\<yield\ze\_s\+\%(return\|break\)\>"
-syn match	csContextualStatement	"\<partial\ze\_s\+\%(class\|struct\|interface\|record\|void\)\>"
 syn match	csContextualStatement	"\<\%(get\|set\|init\|add\|remove\)\ze\_s*\%([;{]\|=>\)"
 syn match	csContextualStatement	"\<where\>\ze[^:]\+:"
 
@@ -192,28 +202,32 @@ hi def link	csRepeat	Repeat
 hi def link	csConditional	Conditional
 hi def link	csLabel	Label
 hi def link	csModifier	StorageClass
+hi def link	csAccessModifier	csModifier
 hi def link	csConstant	Constant
 hi def link	csException	Exception
-hi def link	csTypeOf	Keyword
-hi def link	csTypeOfOperand	Typedef
-hi def link	csTypeOfError	Error
+hi def link	csUnsafeStatement	Statement
 hi def link	csUnspecifiedStatement	Statement
 hi def link	csUnsupportedStatement	Statement
 hi def link	csUnspecifiedKeyword	Keyword
 hi def link	csNew	Statement
 hi def link	csLinq	Statement
 hi def link	csIsAs 	Keyword
-hi def link	csAsync	Keyword
+hi def link	csAsyncModifier	csModifier
 hi def link	csContextualStatement	Statement
-hi def link	csOperatorError	Error
 
 hi def link	csTodo	Todo
 hi def link	csComment	Comment
 hi def link	csLineComment	csComment
 hi def link	csBlockComment	csComment
 
+hi def link	csKeywordOperator	Keyword
+hi def link	csAsyncOperator	csKeywordOperator
+hi def link	csTypeOf	csKeywordOperator
+hi def link	csTypeOfOperand	Typedef
+hi def link	csTypeOfError	Error
 hi def link	csOpSymbols	Operator
 hi def link	csLogicSymbols	Operator
+hi def link	csOperatorError	Error
 
 hi def link	csSpecialError	Error
 hi def link	csSpecialCharError	Error

--- a/test/keywords.vader
+++ b/test/keywords.vader
@@ -19,26 +19,9 @@ Execute:
   normal! f@
   AssertEqual 'csIdentifier', SyntaxAt()
 
-Given cs (partial types):
-  partial class         Foobar {}
-  partial interface     Foobar {}
-  partial struct        Foobar {}
-  partial record        Foobar {}
-  partial record class  Foobar {}
-  partial record struct Foobar {}
+Given cs (unsafe statement):
+  unsafe { /* boom! */ }
 
 Execute:
-  AssertEqual 'csContextualStatement', SyntaxAt(1, 1)
-  AssertEqual 'csContextualStatement', SyntaxAt(2, 1)
-  AssertEqual 'csContextualStatement', SyntaxAt(3, 1)
-  AssertEqual 'csContextualStatement', SyntaxAt(4, 1)
-  AssertEqual 'csContextualStatement', SyntaxAt(5, 1)
-  AssertEqual 'csContextualStatement', SyntaxAt(6, 1)
-
-Given cs (partial methods):
-  partial void Foobar();
-
-Execute:
-  AssertEqual 'csContextualStatement', SyntaxAt()
-
+  AssertEqual 'csUnsafeStatement', SyntaxAt(1, 1)
 

--- a/test/modifiers.vader
+++ b/test/modifiers.vader
@@ -1,0 +1,34 @@
+Given cs (unsafe modifier):
+  unsafe void foobar() { /* boom! */ }
+
+Execute:
+  AssertEqual 'csModifier', SyntaxAt(1, 1)
+
+Given cs (async modifier):
+  async void foobar() {}
+
+Execute:
+  AssertEqual 'csAsyncModifier', SyntaxAt(1, 1)
+
+Given cs (partial types):
+  partial class         Foobar {}
+  partial interface     Foobar {}
+  partial struct        Foobar {}
+  partial record        Foobar {}
+  partial record class  Foobar {}
+  partial record struct Foobar {}
+
+Execute:
+  AssertEqual 'csModifier', SyntaxAt(1, 1)
+  AssertEqual 'csModifier', SyntaxAt(2, 1)
+  AssertEqual 'csModifier', SyntaxAt(3, 1)
+  AssertEqual 'csModifier', SyntaxAt(4, 1)
+  AssertEqual 'csModifier', SyntaxAt(5, 1)
+  AssertEqual 'csModifier', SyntaxAt(6, 1)
+
+Given cs (partial methods):
+  partial void Foobar();
+
+Execute:
+  AssertEqual 'csModifier', SyntaxAt()
+

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -71,6 +71,8 @@ Execute:
   normal! f>
   AssertEqual 'csGenericBraces', SyntaxAt()
 
+# Keyword operators
+
 Given cs (typeof operator):
   typeof(Dictionary<string,List<Image>>)
 
@@ -95,3 +97,9 @@ Given cs (typeof operator with missing operand parens):
 Execute:
   AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
   AssertEqual 'csTypeOfError',    SyntaxAt(1, 8)
+
+Given cs (await operator):
+  await foobar();
+
+Execute:
+  AssertEqual 'csAsyncOperator', SyntaxAt(1, 1)


### PR DESCRIPTION
I've left `async`/`await` linked to `Keyword` as they were, for the moment, but personally I'd link them to `csModifier` and `(cs)Operator`.  Categorising keywords is occasionally a bit arbitrary but MS has been good enough to do it for us in the documentation so I reckon we may as well go with that when in doubt.

Are you alright with having these sort of incomplete fixes committed as long as we're moving forward rather than waiting for the more complicated stragglers like `in`, `out`, and `new`?  I'd be inclined to approach them from another angle with separate pull requests for improvements to generics and distinguishing the several uses of `new`.


keywords.vader is a bit of a dumping ground for the moment...
