### PR TITLE
Differentiate uses of overloaded statement keywords

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -49,9 +49,9 @@ syn keyword	csAsyncOperator	await
 syn match	csStorage	"\<extern\ze\s\+alias\>"
 syn match	csStorage	"\%(\<extern\s\+\)\@16<=alias\>"
 
-syn match	csUnsafeStatement	"\<unsafe\ze\_s*{"
+syn match	csStatement	"\<\%(checked\|unchecked\|unsafe\)\ze\_s*{"
 
-syn keyword	csUnspecifiedStatement	as base checked fixed in is lock nameof operator out params ref sizeof stackalloc this unchecked using
+syn keyword	csUnspecifiedStatement	as base fixed in is lock nameof operator out params ref sizeof stackalloc this using
 syn keyword	csUnsupportedStatement	value
 syn keyword	csUnspecifiedKeyword	explicit implicit
 
@@ -64,6 +64,7 @@ syn match	csContextualStatement	"\<where\>\ze[^:]\+:"
 syn keyword	csTypeOf	typeof nextgroup=csTypeOfOperand,csTypeOfError skipwhite skipempty
 syn region	csTypeOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
 syn match       csTypeOfError               "[^([:space:]]" contained
+syn match	csKeywordOperator	"\<\%(checked\|unchecked\)\ze\_s*("
 
 " Punctuation
 syn match	csBraces	"[{}\[\]]" display
@@ -208,7 +209,6 @@ hi def link	csModifier	StorageClass
 hi def link	csAccessModifier	csModifier
 hi def link	csConstant	Constant
 hi def link	csException	Exception
-hi def link	csUnsafeStatement	Statement
 hi def link	csUnspecifiedStatement	Statement
 hi def link	csUnsupportedStatement	Statement
 hi def link	csUnspecifiedKeyword	Keyword

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -36,7 +36,7 @@ syn match	csLabel	display +^\s*\I\i*\s*:\%([^:]\)\@=+
 syn keyword	csAccessModifier	internal private protected public
 " TODO: in new out
 syn keyword	csModifier	abstract const event override readonly sealed static virtual volatile
-syn match	csModifier	"\<\%(extern\|unsafe\)\>"
+syn match	csModifier	"\<\%(extern\|fixed\|unsafe\)\>"
 syn match	csModifier	"\<partial\ze\_s\+\%(class\|struct\|interface\|record\|void\)\>"
 
 syn keyword	csException	try catch finally throw when
@@ -50,8 +50,9 @@ syn match	csStorage	"\<extern\ze\s\+alias\>"
 syn match	csStorage	"\%(\<extern\s\+\)\@16<=alias\>"
 
 syn match	csStatement	"\<\%(checked\|unchecked\|unsafe\)\ze\_s*{"
+syn match	csStatement	"\<fixed\ze\_s*("
 
-syn keyword	csUnspecifiedStatement	as base fixed in is lock nameof operator out params ref sizeof stackalloc this using
+syn keyword	csUnspecifiedStatement	as base in is lock nameof operator out params ref sizeof stackalloc this using
 syn keyword	csUnsupportedStatement	value
 syn keyword	csUnspecifiedKeyword	explicit implicit
 

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -51,13 +51,14 @@ syn match	csStorage	"\%(\<extern\s\+\)\@16<=alias\>"
 
 syn match	csStatement	"\<\%(checked\|unchecked\|unsafe\)\ze\_s*{"
 syn match	csStatement	"\<fixed\ze\_s*("
+syn keyword	csStatement	lock
+syn match	csStatement	"\<yield\ze\_s\+\%(return\|break\)\>"
 
-syn keyword	csUnspecifiedStatement	as base in is lock nameof operator out params ref sizeof stackalloc this using
+syn keyword	csUnspecifiedStatement	as base in is nameof operator out params ref sizeof stackalloc this using
 syn keyword	csUnsupportedStatement	value
 syn keyword	csUnspecifiedKeyword	explicit implicit
 
 " Contextual Keywords
-syn match	csContextualStatement	"\<yield\ze\_s\+\%(return\|break\)\>"
 syn match	csContextualStatement	"\<\%(get\|set\|init\|add\|remove\)\ze\_s*\%([;{]\|=>\)"
 syn match	csContextualStatement	"\<where\>\ze[^:]\+:"
 

--- a/test/identifiers.vader
+++ b/test/identifiers.vader
@@ -1,0 +1,12 @@
+Given cs (verbatim identifiers):
+  var @new = 42;
+
+Execute:
+  AssertEqual 'csIdentifier', SyntaxOf('@new')
+
+Given cs (yield as identifier):
+  var yield = 42;
+
+Execute:
+  AssertEqual '', SyntaxOf('yield')
+

--- a/test/keywords.vader
+++ b/test/keywords.vader
@@ -12,10 +12,3 @@ Execute:
   AssertEqual 'csModifier',   SyntaxAt(1, 1)
   AssertEqual 'csType',       SyntaxAt(1, 8)
 
-Given cs (keyword identifiers):
-  var @new = 42;
-
-Execute:
-  normal! f@
-  AssertEqual 'csIdentifier', SyntaxAt()
-

--- a/test/keywords.vader
+++ b/test/keywords.vader
@@ -19,9 +19,3 @@ Execute:
   normal! f@
   AssertEqual 'csIdentifier', SyntaxAt()
 
-Given cs (unsafe statement):
-  unsafe { /* boom! */ }
-
-Execute:
-  AssertEqual 'csUnsafeStatement', SyntaxAt(1, 1)
-

--- a/test/modifiers.vader
+++ b/test/modifiers.vader
@@ -30,5 +30,11 @@ Given cs (partial methods):
   partial void Foobar();
 
 Execute:
-  AssertEqual 'csModifier', SyntaxAt()
+  AssertEqual 'csModifier', SyntaxAt(1, 1)
+
+Given cs (fixed modifier):
+  fixed byte foobar[42];
+
+Execute:
+  AssertEqual 'csModifier', SyntaxAt(1, 1)
 

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -108,11 +108,11 @@ Given cs (checked operator):
   var foobar = checked(42 + 1);
 
 Execute:
-  AssertEqual 'csKeywordOperator', SyntaxAt(1, 14)
+  AssertEqual 'csKeywordOperator', SyntaxOf('checked')
 
 Given cs (unchecked operator):
   var foobar = unchecked(42 + 1);
 
 Execute:
-  AssertEqual 'csKeywordOperator', SyntaxAt(1, 14)
+  AssertEqual 'csKeywordOperator', SyntaxOf('unchecked')
 

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -103,3 +103,16 @@ Given cs (await operator):
 
 Execute:
   AssertEqual 'csAsyncOperator', SyntaxAt(1, 1)
+
+Given cs (checked operator):
+  var foobar = checked(42 + 1);
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxAt(1, 14)
+
+Given cs (unchecked operator):
+  var foobar = unchecked(42 + 1);
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxAt(1, 14)
+

--- a/test/statements.vader
+++ b/test/statements.vader
@@ -16,3 +16,9 @@ Given cs (unchecked statement):
 Execute:
   AssertEqual 'csStatement', SyntaxAt(1, 1)
 
+Given cs (fixed statement):
+  fixed (int* i = foobar) { /* ... */ }
+
+Execute:
+  AssertEqual 'csStatement', SyntaxAt(1, 1)
+

--- a/test/statements.vader
+++ b/test/statements.vader
@@ -1,0 +1,18 @@
+Given cs (unsafe statement):
+  unsafe { /* boom! */ }
+
+Execute:
+  AssertEqual 'csStatement', SyntaxAt(1, 1)
+
+Given cs (checked statement):
+  checked { /* boom! */ }
+
+Execute:
+  AssertEqual 'csStatement', SyntaxAt(1, 1)
+
+Given cs (unchecked statement):
+  unchecked { /* boom! */ }
+
+Execute:
+  AssertEqual 'csStatement', SyntaxAt(1, 1)
+

--- a/test/statements.vader
+++ b/test/statements.vader
@@ -22,3 +22,17 @@ Given cs (fixed statement):
 Execute:
   AssertEqual 'csStatement', SyntaxAt(1, 1)
 
+Given cs (lock statement):
+  lock (foobar) { /* ... */ }
+
+Execute:
+  AssertEqual 'csStatement', SyntaxAt(1, 1)
+
+Given cs (yield statement):
+  yield break;
+  yield return 42;
+
+Execute:
+  AssertEqual 'csStatement', SyntaxAt(1, 1)
+  AssertEqual 'csStatement', SyntaxAt(2, 1)
+


### PR DESCRIPTION
- Differentiate between (un)checked operators and statements
- Differentiate between fixed modifiers and statements
- Move lock and yield keywords to the csStatement group
