### PR TITLE
Add more keyword operators

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -261,7 +261,7 @@ hi def link	csException	Exception
 hi def link	csUnspecifiedStatement	Statement
 hi def link	csUnsupportedStatement	Statement
 hi def link	csUnspecifiedKeyword	Keyword
-hi def link	csNew	Statement
+hi def link	csNew	csKeywordOperator
 hi def link	csLinq	Statement
 hi def link	csIsAs 	csKeywordOperator
 hi def link	csAsyncModifier	csModifier

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -29,7 +29,9 @@ syn match	csStorage	"\<delegate\>"
 syn keyword	csRepeat	break continue do for foreach goto return while
 syn keyword	csConditional	else if
 syn match	csCondtional	"\<switch\>"
-syn keyword	csLabel	case default
+
+syn keyword	csLabel	case
+syn match	csLabel	"\<default\ze\_s*:"
 
 syn match	csNamespaceAlias	"@\=\h\w*\ze\_s*::" display
 syn match	csGlobalNamespaceAlias	"global\ze\_s*::" display
@@ -89,6 +91,9 @@ syn region	csSizeOfOperand	matchgroup=csParens start="(" end=")" contained conta
 
 syn keyword	csKeywordOperator	nameof nextgroup=csNameOfOperand,csMissingParenError skipwhite skipempty
 syn region	csNameOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
+
+syn match	csKeywordOperator	"\<default\_s*\ze(" nextgroup=csDefaultOperand,csMissingParenError skipwhite skipempty
+syn region	csDefaultOperand	matchgroup=csParens start="(" end=")" contained contains=csType
 
 syn match       csMissingParenError         "[^([:space:]]" contained
 
@@ -178,6 +183,9 @@ syn keyword	csIsAs	is as
 
 syn keyword	csBoolean	false true
 syn keyword	csNull	null
+syn match	csDefault	"\<default\>\%(\_s*[(:]\)\@!"
+" ternary consequent
+syn match	csDefault	"\%(?\_s*\)\@32<=default\>"
 
 " Strings and constants
 syn match	csSpecialError	"\\." contained
@@ -211,7 +219,7 @@ syn region	csInterpolatedString	matchgroup=csQuote start=+\$"+ end=+"+ extend co
 syn region	csInterpolation	matchgroup=csInterpolationDelimiter start=+{+ end=+}+ keepend contained contains=@csAll,csBraced,csBracketed,csInterpolationAlign,csInterpolationFormat
 syn match	csEscapedInterpolation	"{{" transparent contains=NONE display
 syn match	csEscapedInterpolation	"}}" transparent contains=NONE display
-syn region	csInterpolationAlign	matchgroup=csInterpolationAlignDel start=+,+ end=+}+ end=+:+me=e-1 contained contains=@csNumber,csBoolean,csConstant,csCharacter,csParens,csOpSymbols,csString,csBracketed display
+syn region	csInterpolationAlign	matchgroup=csInterpolationAlignDel start=+,+ end=+}+ end=+:+me=e-1 contained contains=@csNumber,csBoolean,csLiteral,csCharacter,csParens,csOpSymbols,csString,csBracketed display
 syn match	csInterpolationFormat	+:[^}]\+}+ contained contains=csInterpolationFormatDel display
 syn match	csInterpolationAlignDel	+,+ contained display
 syn match	csInterpolationFormatDel	+:+ contained display
@@ -246,8 +254,9 @@ hi def link	csModifier	StorageClass
 hi def link	csAccessModifier	csModifier
 hi def link	csManagedModifier	csModifier
 hi def link	csUsingModifier	csModifier
-hi def link	csConstant	Constant
-hi def link	csNull	Constant
+hi def link	csLiteral	Constant
+hi def link	csNull	csLiteral
+hi def link	csDefault	csLiteral
 hi def link	csException	Exception
 hi def link	csUnspecifiedStatement	Statement
 hi def link	csUnsupportedStatement	Statement
@@ -270,6 +279,7 @@ hi def link	csKeywordOperator	Keyword
 hi def link	csAsyncOperator	csKeywordOperator
 hi def link	csTypeOfOperand	Typedef
 hi def link	csSizeOfOperand	Typedef
+hi def link	csDefaultOperand	Typedef
 hi def link	csMissingParenError	Error
 hi def link	csOpSymbols	Operator
 hi def link	csLogicSymbols	Operator

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -27,7 +27,8 @@ syn keyword	csType	nint nuint " contextual
 syn keyword	csStorage	enum interface namespace struct
 syn match	csStorage	"\<delegate\>"
 syn keyword	csRepeat	break continue do for foreach goto return while
-syn keyword	csConditional	else if switch
+syn keyword	csConditional	else if
+syn match	csCondtional	"\<switch\>"
 syn keyword	csLabel	case default
 
 syn match	csNamespaceAlias	"@\=\h\w*\ze\_s*::" display
@@ -66,7 +67,7 @@ syn match	csStatement	"\<yield\ze\_s\+\%(return\|break\)\>"
 
 syn match	csAccessor	"\<\%(get\|set\|init\|add\|remove\)\ze\_s*\%([;{]\|=>\)"
 
-syn keyword	csUnspecifiedStatement	as base in is nameof operator out params ref sizeof stackalloc this using
+syn keyword	csUnspecifiedStatement	as base in is operator out params ref this using
 syn keyword	csUnsupportedStatement	value
 syn keyword	csUnspecifiedKeyword	explicit implicit
 
@@ -74,10 +75,22 @@ syn keyword	csUnspecifiedKeyword	explicit implicit
 syn match	csContextualStatement	"\<where\>\ze[^:]\+:"
 
 " Operators
-syn keyword	csTypeOf	typeof nextgroup=csTypeOfOperand,csTypeOfError skipwhite skipempty
-syn region	csTypeOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
-syn match       csTypeOfError               "[^([:space:]]" contained
+syn keyword	csKeywordOperator	stackalloc
 syn match	csKeywordOperator	"\<\%(checked\|unchecked\)\ze\_s*("
+syn match	csKeywordOperator	"\<delegate\ze\_s*[({]"
+syn match	csKeywordOperator	"\<switch\ze\_s*{"
+syn match	csKeywordOperator	"\<with\ze\_s*{"
+
+syn keyword	csKeywordOperator	typeof nextgroup=csTypeOfOperand,csMissingParenError skipwhite skipempty
+syn region	csTypeOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
+
+syn keyword	csKeywordOperator	sizeof nextgroup=csSizeOfOperand,csMissingParenError skipwhite skipempty
+syn region	csSizeOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
+
+syn keyword	csKeywordOperator	nameof nextgroup=csNameOfOperand,csMissingParenError skipwhite skipempty
+syn region	csNameOfOperand	matchgroup=csParens start="(" end=")" contained contains=csType
+
+syn match       csMissingParenError         "[^([:space:]]" contained
 
 " Punctuation
 syn match	csBraces	"[{}\[\]]" display
@@ -215,7 +228,7 @@ syn cluster	csLiteral	contains=csBoolean,@csNumber,csCharacter,@csString,csNull
 syn region	csBracketed	matchgroup=csParens start=+(+ end=+)+ extend contained transparent contains=@csAll,csBraced,csBracketed
 syn region	csBraced	matchgroup=csParens start=+{+ end=+}+ extend contained transparent contains=@csAll,csBraced,csBracketed
 
-syn cluster	csAll	contains=@csLiteral,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csOpSymbols,csParens,@csPreProcessor,csSummary,@csNamespaceAlias,csType,csUnicodeNumber,csUserType,csUserIdentifier,csUserInterface,csUserMethod
+syn cluster	csAll	contains=@csLiteral,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csOpSymbols,csKeywordOperator,csParens,@csPreProcessor,csSummary,@csNamespaceAlias,csType,csUnicodeNumber,csUserType,csUserIdentifier,csUserInterface,csUserMethod
 
 " Keyword identifiers
 syn match csIdentifier "@\h\w*"
@@ -241,7 +254,7 @@ hi def link	csUnsupportedStatement	Statement
 hi def link	csUnspecifiedKeyword	Keyword
 hi def link	csNew	Statement
 hi def link	csLinq	Statement
-hi def link	csIsAs 	Keyword
+hi def link	csIsAs 	csKeywordOperator
 hi def link	csAsyncModifier	csModifier
 hi def link	csStatement	Statement
 hi def link	csContextualStatement	Statement
@@ -255,9 +268,9 @@ hi def link	csBlockComment	csComment
 
 hi def link	csKeywordOperator	Keyword
 hi def link	csAsyncOperator	csKeywordOperator
-hi def link	csTypeOf	csKeywordOperator
 hi def link	csTypeOfOperand	Typedef
-hi def link	csTypeOfError	Error
+hi def link	csSizeOfOperand	Typedef
+hi def link	csMissingParenError	Error
 hi def link	csOpSymbols	Operator
 hi def link	csLogicSymbols	Operator
 

--- a/test/literals.vader
+++ b/test/literals.vader
@@ -6,6 +6,18 @@ Execute:
   AssertEqual 'csBoolean',              SyntaxAt(1, 1)
   AssertEqual 'csBoolean',              SyntaxAt(2, 1)
 
+Given cs (default literal):
+  default
+
+Execute:
+  AssertEqual 'csDefault',                SyntaxAt(1, 1)
+
+Given cs (default literal - ternary consequent):
+  var foo = bar ? default : 42;
+
+Execute:
+  AssertEqual 'csDefault',                SyntaxOf('default')
+
 Given cs (null):
   null
 

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -77,32 +77,82 @@ Given cs (typeof operator):
   typeof(Dictionary<string,List<Image>>)
 
 Execute:
-  AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
-  AssertEqual 'csParens',         SyntaxAt(1, 7)
-  AssertEqual 'csTypeOfOperand',  SyntaxAt(1, 8)
-  AssertEqual 'csParens',         SyntaxAt(1, 38)
+  AssertEqual 'csKeywordOperator', SyntaxOf('typeof')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csTypeOfOperand',   SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
 
 Given cs (typeof operator with space before open paren):
   typeof (Dictionary<string,List<Image>>)
 
 Execute:
-  AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
-  AssertEqual 'csParens',         SyntaxAt(1, 8)
-  AssertEqual 'csTypeOfOperand',  SyntaxAt(1, 9)
-  AssertEqual 'csParens',         SyntaxAt(1, 39)
+  AssertEqual 'csKeywordOperator', SyntaxOf('typeof')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csTypeOfOperand',   SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
 
 Given cs (typeof operator with missing operand parens):
   typeof Dictionary<string,List<Image>>
 
 Execute:
-  AssertEqual 'csTypeOf',         SyntaxAt(1, 1)
-  AssertEqual 'csTypeOfError',    SyntaxAt(1, 8)
+  AssertEqual 'csKeywordOperator',   SyntaxOf('typeof')
+  AssertEqual 'csMissingParenError', SyntaxAt(1, 8)
+
+Given cs (sizeof operator):
+  sizeof(byte)
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('sizeof')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csType',            SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
+
+Given cs (sizeof operator with space before open paren):
+  sizeof (byte)
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('sizeof')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csType',            SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
+
+Given cs (sizeof operator with missing operand parens):
+  sizeof byte
+
+Execute:
+  AssertEqual 'csKeywordOperator',   SyntaxOf('sizeof')
+  AssertEqual 'csMissingParenError', SyntaxOf('b\zeyte')
+
+Given cs (nameof operator):
+  nameof(foobar)
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('nameof')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csNameOfOperand',   SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
+
+Given cs (nameof operator with space before open paren):
+  nameof (foobar)
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('nameof')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csNameOfOperand',   SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
+
+Given cs (nameof operator with missing operand parens):
+  nameof foobar
+
+Execute:
+  AssertEqual 'csKeywordOperator',   SyntaxOf('nameof')
+  AssertEqual 'csMissingParenError', SyntaxOf('f\zeoobar')
 
 Given cs (await operator):
   await foobar();
 
 Execute:
-  AssertEqual 'csAsyncOperator', SyntaxAt(1, 1)
+  AssertEqual 'csAsyncOperator', SyntaxOf('await')
 
 Given cs (checked operator):
   var foobar = checked(42 + 1);
@@ -115,4 +165,30 @@ Given cs (unchecked operator):
 
 Execute:
   AssertEqual 'csKeywordOperator', SyntaxOf('unchecked')
+
+Given cs (stackalloc operator):
+  Span<byte> foobar = stackalloc byte[42];
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('stackalloc')
+
+Given cs (switch operator):
+  var foo = bar switch { _ => 42 };
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('switch')
+
+Given cs (delegate operator):
+  Func<int> foobar = delegate (int a) { return 42; };
+     Action foobar = delegate { FortyTwo(); };
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('delegate', 1)
+  AssertEqual 'csKeywordOperator', SyntaxOf('delegate', 2)
+
+Given cs (with operator):
+  var foo = bar with { Baz = 42 };
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('with')
 

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -192,6 +192,12 @@ Given cs (unchecked operator):
 Execute:
   AssertEqual 'csKeywordOperator', SyntaxOf('unchecked')
 
+Given cs (new operator):
+  var foo = new Bar();
+
+Execute:
+  AssertEqual 'csNew', SyntaxOf('new')
+
 Given cs (stackalloc operator):
   Span<byte> foobar = stackalloc byte[42];
 

--- a/test/operators.vader
+++ b/test/operators.vader
@@ -73,6 +73,32 @@ Execute:
 
 # Keyword operators
 
+Given cs (default operator):
+  default(Dictionary<string,List<Image>>)
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('default')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csDefaultOperand',   SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
+
+Given cs (default operator with space before open paren):
+  default (Dictionary<string,List<Image>>)
+
+Execute:
+  AssertEqual 'csKeywordOperator', SyntaxOf('default')
+  AssertEqual 'csParens',          SyntaxOf('(')
+  AssertEqual 'csDefaultOperand',   SyntaxOf('(\zs')
+  AssertEqual 'csParens',          SyntaxOf(')')
+
+Given cs (default operator with missing operand parens):
+  default Dictionary<string,List<Image>>
+
+Execute:
+# TODO: Not enough context in default literal matching to match this as a
+#       missing paren operator call
+  AssertEqual 'csDefault',   SyntaxOf('default')
+
 Given cs (typeof operator):
   typeof(Dictionary<string,List<Image>>)
 

--- a/test/statements.vader
+++ b/test/statements.vader
@@ -1,3 +1,9 @@
+Given cs (switch statement - default case label):
+  switch (42) { default: ; break; }
+
+Execute:
+  AssertEqual 'csLabel', SyntaxOf('default')
+
 Given cs (unsafe statement):
   unsafe { /* boom! */ }
 


### PR DESCRIPTION
Intentionally excluding `new` modifier and type constraint and `default` type constraint uses for now.