### PR TITLE
Add some convenience syntax clusters

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -155,7 +155,7 @@ syn keyword	csClass	class contained
 syn keyword	csIsAs	is as
 
 syn keyword	csBoolean	false true
-syn keyword	csConstant	null
+syn keyword	csNull	null
 
 " Strings and constants
 syn match	csSpecialError	"\\." contained
@@ -220,6 +220,7 @@ hi def link	csModifier	StorageClass
 hi def link	csAccessModifier	csModifier
 hi def link	csManagedModifier	csModifier
 hi def link	csConstant	Constant
+hi def link	csNull	Constant
 hi def link	csException	Exception
 hi def link	csUnspecifiedStatement	Statement
 hi def link	csUnsupportedStatement	Statement

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -145,6 +145,8 @@ if expand('%:e') == 'csx' || getline('1') =~ '^#!.*\<dotnet-script\>'
   syn match	csShebang	"\%^#!.*" display
 endif
 
+syn cluster	csPreProcessor	contains=csPreProc.*
+
 syn region	csClassType	start="\<class\>"hs=s+6 end="[:\n{]"me=e-1 contains=csClass
 " csUserType may be defined by user scripts/plugins - it should be contained in csNewType
 syn region	csNewType	start="\<new\>"hs=s+4 end="[;\n{(<\[]"me=e-1 contains=csNew,csUserType
@@ -206,7 +208,7 @@ syn cluster	csLiteral	contains=csBoolean,@csNumber,csCharacter,@csString,csNull
 syn region	csBracketed	matchgroup=csParens start=+(+ end=+)+ extend contained transparent contains=@csAll,csBraced,csBracketed
 syn region	csBraced	matchgroup=csParens start=+{+ end=+}+ extend contained transparent contains=@csAll,csBraced,csBracketed
 
-syn cluster	csAll	contains=@csLiteral,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csOpSymbols,csParens,csPreCondit,csRegion,csSummary,csType,csUnicodeNumber,csUserType,csUserIdentifier,csUserInterface,csUserMethod
+syn cluster	csAll	contains=@csLiteral,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csOpSymbols,csParens,@csPreProcessor,csSummary,csType,csUnicodeNumber,csUserType,csUserIdentifier,csUserInterface,csUserMethod
 
 " Keyword identifiers
 syn match csIdentifier "@\h\w*"

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -199,10 +199,14 @@ syn match	csVerbatimQuote	+""+ contained
 
 syn region	csInterVerbString	matchgroup=csQuote start=+$@"+ start=+@$"+ end=+"+ skip=+""+ extend contains=csInterpolation,csEscapedInterpolation,csSpecialChar,csSpecialError,csUnicodeNumber,csVerbatimQuote,@Spell
 
+syn cluster	csString	contains=csString,csInterpolatedString,csVerbatimString,csInterVerbString
+
+syn cluster	csLiteral	contains=csBoolean,@csNumber,csCharacter,@csString,csNull
+
 syn region	csBracketed	matchgroup=csParens start=+(+ end=+)+ extend contained transparent contains=@csAll,csBraced,csBracketed
 syn region	csBraced	matchgroup=csParens start=+{+ end=+}+ extend contained transparent contains=@csAll,csBraced,csBracketed
 
-syn cluster	csAll	contains=csCharacter,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csBoolean,csConstant,@csNumber,csOpSymbols,csParens,csPreCondit,csRegion,csString,csSummary,csType,csUnicodeNumber,csUnicodeSpecifier,csInterpolatedString,csVerbatimString,csInterVerbString,csUserType,csUserIdentifier,csUserInterface,csUserMethod
+syn cluster	csAll	contains=@csLiteral,csClassType,@csComment,csContextualStatement,csEndColon,csIsType,csLabel,csLogicSymbols,csNewType,csOpSymbols,csParens,csPreCondit,csRegion,csSummary,csType,csUnicodeNumber,csUserType,csUserIdentifier,csUserInterface,csUserMethod
 
 " Keyword identifiers
 syn match csIdentifier "@\h\w*"

--- a/test/literals.vader
+++ b/test/literals.vader
@@ -10,7 +10,7 @@ Given cs (null):
   null
 
 Execute:
-  AssertEqual 'csConstant',             SyntaxAt(1, 1)
+  AssertEqual 'csNull',                   SyntaxAt(1, 1)
 
 Given cs (chars):
   'a'


### PR DESCRIPTION
- Add a csLiteral cluster
- Add a csPreProcessor cluster

Are those csUser\* groups used for a specific purpose somewhere or just convenience hooks?
