### PR TITLE
Add initial support for raw string literals

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -190,6 +190,18 @@ syn match	csUnicodeNumber	+\\U00\x\{6}+ contained contains=csUnicodeSpecifier di
 syn match	csUnicodeSpecifier	+\\[uUx]+ contained display
 
 syn region	csString	matchgroup=csQuote start=+"+ end=+"\%(u8\)\=+ end=+$+ extend contains=csSpecialChar,csSpecialError,csUnicodeNumber,@Spell
+
+for s:i in range(3, get(g:, "cs_raw_string_quote_count", 8))
+  exe 'syn region csRawString'       .. s:i .. ' matchgroup=csQuote start=+\z("\{' .. s:i .. '}\)+ end=+\z1+ oneline nextgroup=csRawStringError' .. s:i
+  exe 'syn region csRawString'       .. s:i .. ' matchgroup=csQuote start=+\z("\{' .. s:i .. '}\)\s*$+ end=+^\s*\z1+ nextgroup=csRawStringError' .. s:i .. ' contains=csRawStringError' .. s:i
+  exe 'syn match  csRawStringError'  .. s:i .. ' /\%("\{'        .. s:i .. '}\)\@' .. s:i .. '<="\+/ contained'
+  exe 'syn match  csRawStringError'  .. s:i .. ' /\S.\{-}\s*"\{' .. s:i .. '}"\@!/ contained'
+
+  exe 'hi def link csRawString'      .. s:i .. ' csString'
+  exe 'hi def link csRawStringError' .. s:i .. ' Error'
+endfor
+unlet s:i
+
 syn match	csCharacter	"'[^']*'" contains=csSpecialChar,csSpecialCharError,csUnicodeNumber display
 syn match	csCharacter	"'\\''" contains=csSpecialChar display
 syn match	csCharacter	"'[^\\]'" display
@@ -217,11 +229,26 @@ syn match	csInterpolationAlignDel	+,+ contained display
 syn match	csInterpolationFormatDel	+:+ contained display
 
 syn region	csVerbatimString	matchgroup=csQuote start=+@"+ end=+"\%(u8\)\=+ skip=+""+ extend contains=csVerbatimQuote,@Spell
+
+" Interpolated raw string literals
+for s:i in range(1, get(g:, "cs_raw_string_interpolation_brace_count", 8))
+  exe 'syn region csInterpolatedRawString'       .. s:i .. ' matchgroup=csQuote start=+$\{' .. s:i .. '}\z("""\+\)+ end=+\z1+ extend contains=csInterpolation' .. s:i .. ',csInterpolationDelimiterError' .. s:i .. ',@Spell'
+  exe 'syn match  csInterpolationDelimiterError' .. s:i .. ' "}\{' .. s:i .. '}" contained'
+  exe 'syn match  csInterpolationDelimiterError' .. s:i .. ' "{\{' .. 2 * s:i .. ',}" contained'
+  exe 'syn match  csInterpolationDelimiterError' .. s:i .. ' "}\{' .. 2 * s:i .. ',}" contained'
+  exe 'syn region csInterpolation'               .. s:i .. ' matchgroup=csInterpolationDelimiter start=+\%({\{' .. s:i .. '}\)\@' .. s:i .. '<!{\{' .. s:i .. '}{\@!+ end=+}\@<!}\{' .. s:i .. '}\%(}\{' .. s:i .. '}\)\@!+' ..
+        \ ' keepend contained contains=@csAll,csBraced,csBracketed,csInterpolationAlign,csInterpolationFormat,csInterpolationDelimiterError' .. s:i
+
+  exe 'hi def link csInterpolationDelimiterError' .. s:i .. ' Error'
+  exe 'hi def link csInterpolatedRawString'       .. s:i .. ' csRawString'
+endfor
+unlet s:i
+
 syn match	csVerbatimQuote	+""+ contained
 
 syn region	csInterVerbString	matchgroup=csQuote start=+$@"+ start=+@$"+ end=+"\%(u8\)\=+ skip=+""+ extend contains=csInterpolation,csEscapedInterpolation,csSpecialChar,csSpecialError,csUnicodeNumber,csVerbatimQuote,@Spell
 
-syn cluster	csString	contains=csString,csInterpolatedString,csVerbatimString,csInterVerbString
+syn cluster	csString	contains=csString,csInterpolatedString,csVerbatimString,csInterVerbString,csRawString
 
 syn cluster	csLiteral	contains=csBoolean,@csNumber,csCharacter,@csString,csNull
 
@@ -282,6 +309,8 @@ hi def link	csLogicSymbols	Operator
 hi def link	csSpecialError	Error
 hi def link	csSpecialCharError	Error
 hi def link	csString	String
+hi def link	csRawString	csString
+hi def link	csRawStringError	Error
 hi def link	csQuote	String
 hi def link	csInterpolatedString	String
 hi def link	csVerbatimString	String

--- a/test/strings.vader
+++ b/test/strings.vader
@@ -361,3 +361,99 @@ Execute:
   AssertEqual 'csQuote',             SyntaxOf("u8", 2)
   AssertEqual 'csQuote',             SyntaxOf("u8", 3)
   AssertEqual 'csQuote',             SyntaxOf("u8", 4)
+
+Given cs (a single line raw string):
+  """a"""
+
+Execute:
+  AssertEqual 'csQuote',                  SyntaxOf('"""', 1)
+  AssertEqual 'csQuote',                  SyntaxOf('"""', 2)
+  AssertEqual 'csRawString3',             SyntaxOf('a')
+
+Given cs (a multi-line raw string):
+  """
+  a
+  """
+
+Execute:
+  AssertEqual 'csQuote',                  SyntaxOf('"""', 1)
+  AssertEqual 'csQuote',                  SyntaxOf('"""', 2)
+  AssertEqual 'csRawString3',             SyntaxOf('a')
+
+Given cs (an invalid multi-line raw string start delimiter):
+  """ non-whitespace
+  42
+  """
+
+Execute:
+  AssertEqual 'csString',                 SyntaxOf('non-whitespace')
+  AssertEqual 'csInteger',                SyntaxOf('42')
+
+Given cs (an invalid multi-line raw string end delimiter):
+  """
+  a
+  non-whitespace """
+
+Execute:
+  AssertEqual 'csQuote',                  SyntaxOf('"""', 1)
+  AssertEqual 'csRawString3',             SyntaxOf('a')
+  AssertEqual 'csRawStringError3',        SyntaxOf('non-whitespace """')
+
+Given cs (an interpolated raw string - 1 dollar):
+  $"""
+  a
+  {42}
+  {{42}}
+  {{{42}}}
+  b
+  """
+
+Execute:
+  AssertEqual 'csQuote',                        SyntaxOf('$"""')
+  AssertEqual 'csInterpolatedRawString1',       SyntaxOf('a')
+  AssertEqual 'csInterpolationDelimiter',       SyntaxOf('{')
+  AssertEqual 'csInteger',                      SyntaxOf('42')
+  AssertEqual 'csInterpolationDelimiter',       SyntaxOf('}')
+  AssertEqual 'csInterpolationDelimiterError1', SyntaxOf('{{')
+  AssertEqual 'csInterpolatedRawString1',       SyntaxOf('42', 2)
+  AssertEqual 'csInterpolationDelimiterError1', SyntaxOf('}}')
+  AssertEqual 'csInterpolationDelimiterError1', SyntaxOf('{{{')
+  AssertEqual 'csInterpolatedRawString1',       SyntaxOf('42', 3)
+  AssertEqual 'csInterpolationDelimiterError1', SyntaxOf('}}}')
+  AssertEqual 'csInterpolatedRawString1',       SyntaxOf('b')
+  AssertEqual 'csQuote',                        SyntaxOf('"""', 2)
+
+Given cs (an interpolated raw string - 2 dollar):
+  $$"""
+  a
+  {42}
+  {{42}}
+  {{{42}}}
+  {{{{42}}}}
+  {{{{{42}}}}}
+  b
+  """
+
+Execute:
+  AssertEqual 'csQuote',                        SyntaxOf('$"""')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('a')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('{')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('42')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('}')
+  AssertEqual 'csInterpolationDelimiter',       SyntaxOf('{{')
+  AssertEqual 'csInteger',                      SyntaxOf('42', 2)
+  AssertEqual 'csInterpolationDelimiter',       SyntaxOf('}}')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('{\ze{{')
+  AssertEqual 'csInterpolationDelimiter',       SyntaxOf('{\zs{{')
+  AssertEqual 'csInteger',                      SyntaxOf('42', 3)
+  AssertEqual 'csInterpolationDelimiter',       SyntaxOf('}}\ze}')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('}}\zs}')
+  AssertEqual 'csInterpolationDelimiterError2', SyntaxOf('{{{{')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('42', 4)
+  AssertEqual 'csInterpolationDelimiterError2', SyntaxOf('}}}}')
+  AssertEqual 'csInterpolationDelimiterError2', SyntaxOf('{{{{{')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('42', 5)
+  AssertEqual 'csInterpolationDelimiterError2', SyntaxOf('}}}}}')
+  AssertEqual 'csInterpolatedRawString2',       SyntaxOf('b')
+  AssertEqual 'csQuote',                        SyntaxOf('"""', 2)
+


### PR DESCRIPTION
This is incomplete but probably does a decent job highlighting correct code.

TODO: 
* Single-line and multi-line raw strings should be handled separately and more strictly.
* Invalid delimiter sequences should be highlighted as errors.
* Normal strings shouldn't obscure errors by matching in invalid raw string literal syntax.
* Should raw strings be coloured distinctly?
