### PR TITLE
Highlight record as a keyword

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -25,6 +25,9 @@ syn keyword	csType	bool byte char decimal double float int long object sbyte sho
 syn keyword	csType	nint nuint " contextual
 
 syn keyword	csStorage	enum interface namespace struct
+syn match	csStorage	"\<record\ze\_s\+@\=\h\w*\_s*[<(:{;]"
+syn match	csStorage	"\%(\<\%(partial\|new\|public\|protected\|internal\|private\|abstract\|sealed\|static\|unsafe\|readonly\)\)\@9<=\_s\+record\>"
+syn match	csStorage	"\<record\ze\_s\+\%(class\|struct\)"
 syn match	csStorage	"\<delegate\>"
 syn keyword	csRepeat	break continue do for foreach goto return while
 syn keyword	csConditional	else if switch

--- a/test/records.vader
+++ b/test/records.vader
@@ -1,0 +1,67 @@
+Given cs (record matching via body):
+  record Foo {}
+  record struct Foo {}
+  record class Foo {}
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)
+  AssertEqual 'csStorage', SyntaxOf('record', 3)
+
+Given cs (record matching via body):
+  record Foo;
+  record struct Foo;
+  record class Foo;
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)
+  AssertEqual 'csStorage', SyntaxOf('record', 3)
+
+Given cs (record matching via type parameter list):
+  record Foo<T>;
+  record struct Foo<T>;
+  record class Foo<T>;
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)
+  AssertEqual 'csStorage', SyntaxOf('record', 3)
+
+Given cs (record matching via parameter list):
+  record Foo(int X, int Y);
+  record struct Foo(int X, int Y);
+  record class Foo(int X, int Y);
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)
+  AssertEqual 'csStorage', SyntaxOf('record', 3)
+
+Given cs (record matching via base type):
+  record Foo : Bar;
+  record struct Foo : Bar;
+  record class Foo : Bar;
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)
+  AssertEqual 'csStorage', SyntaxOf('record', 3)
+
+Given cs (record matching via modifier):
+  partial record Foo ...
+  partial record struct ...
+  partial record class ...
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)
+  AssertEqual 'csStorage', SyntaxOf('record', 3)
+
+Given cs (record matching via class or struct):
+  record struct ...
+  record class ...
+
+Execute:
+  AssertEqual 'csStorage', SyntaxOf('record', 1)
+  AssertEqual 'csStorage', SyntaxOf('record', 2)


### PR DESCRIPTION
This is probably incomplete and the implementation could be improved using `nextgroup` rather than the look-behind but that might be better implemented as a more general strategy.

@nickspoons, I don't think this causes any harm so it may as well go in for Vim 9 if you have no objections.

Fixes issue #36.
