### PR TITLE
Add g:dotnet_errors_only option for makeprg

### DIFF
--- a/compiler/dotnet.vim
+++ b/compiler/dotnet.vim
@@ -15,7 +15,13 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet makeprg=dotnet\ build\ -nologo\ -consoleloggerparameters:NoSummary
+if get(g:, "dotnet_errors_only", v:false)
+  CompilerSet makeprg=dotnet\ build\ -nologo
+		     \\ -consoleloggerparameters:NoSummary
+		     \\ -consoleloggerparameters:ErrorsOnly
+else
+  CompilerSet makeprg=dotnet\ build\ -nologo\ -consoleloggerparameters:NoSummary
+endif
 
 if get(g:, "dotnet_show_project_file", v:true)
   CompilerSet errorformat=%E%f(%l\\,%c):\ %trror\ %m,


### PR DESCRIPTION
Adds the `g:dotnet_errors_only` option. The default is `v:false` but when set to `v:true` the `-consoleloggerparameters:ErrorsOnly` is added to `dotnet build`, preventing warnings from being included in the build output.