### PR TITLE
setlocal cinoptions=J1

### DIFF
--- a/ftplugin/cs.vim
+++ b/ftplugin/cs.vim
@@ -21,6 +21,8 @@ setlocal formatoptions-=t formatoptions+=croql
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
 
+setlocal cinoptions=J1
+
 let b:undo_ftplugin = 'setl com< fo<'
 
 if exists('loaded_matchit') && !exists('b:match_words')

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -74,3 +74,20 @@ Expect cs(correct indentation):
               string m_PrettyName = "";
       }
   }
+
+Given cs (an object initialization with more than one property):
+  return new LoginResponse
+  {
+  Success = false,
+  Message = _frameworkSettings.InvalidLoginErrorMessage
+  };
+
+Execute:
+  normal! gg=G
+
+Expect cs(correct indentation):
+  return new LoginResponse
+  {
+      Success = false,
+      Message = _frameworkSettings.InvalidLoginErrorMessage
+  };


### PR DESCRIPTION
The '`cinoptions'` `J` option [:help cino-J](http://vimhelp.appspot.com/indent.txt.html#cino-J) was mentioned previously in #68. In that issue I mentioned that no runtime files set this option but there are actually a handful that do: rust, zip, hare and odin.

This is a good fit for C# too so I'll add it.