### PR TITLE
fix: add missing commentstring option

### DIFF
--- a/ftplugin/cs.vim
+++ b/ftplugin/cs.vim
@@ -20,6 +20,7 @@ setlocal formatoptions-=t formatoptions+=croql
 
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
+setlocal commentstring=//\ %s
 
 setlocal cinoptions=J1
 


### PR DESCRIPTION
Fixes #70 

I've cloned neovim locally and applied this patch to this file to verify:
https://github.com/neovim/neovim/blob/master/runtime/ftplugin/cs.vim

Works exactly how I expect it. Neovim's built-in commenting now uses the correct prefix when commenting out lines.

Appreciate if this could be merged, then upstreamed to vim when convenient to do so. If you have any questions, please let me know.